### PR TITLE
Give option to use different namespace when installing/uninstalling 

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -8,13 +8,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var installOptions install.Options
+
 // installCmd represents the get command
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install KubeArmor in a Kubernetes Cluster",
 	Long:  `Install KubeArmor in a Kubernetes Clusters`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := install.K8sInstaller(client); err != nil {
+		if err := install.K8sInstaller(client, installOptions); err != nil {
 			return err
 		}
 		return nil
@@ -23,4 +25,6 @@ var installCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(installCmd)
+
+	installCmd.Flags().StringVarP(&installOptions.Namespace, "namespace", "n", "kube-system", "Namespace for resources")
 }

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -8,13 +8,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var uninstallOptions install.Options
+
 // uninstallCmd represents the get command
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
 	Short: "Uninstall KubeArmor from a Kubernetes Cluster",
 	Long:  `Uninstall KubeArmor from a Kubernetes Clusters`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := install.K8sUninstaller(client); err != nil {
+		if err := install.K8sUninstaller(client, uninstallOptions); err != nil {
 			return err
 		}
 		return nil
@@ -23,4 +25,6 @@ var uninstallCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(uninstallCmd)
+
+	uninstallCmd.Flags().StringVarP(&uninstallOptions.Namespace, "namespace", "n", "kube-system", "Namespace for resources")
 }

--- a/install/install.go
+++ b/install/install.go
@@ -14,7 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func K8sInstaller(c *k8s.Client) error {
+type Options struct {
+	Namespace string
+}
+
+func K8sInstaller(c *k8s.Client, o Options) error {
 	env := autoDetectEnvironment(c)
 	if env == "none" {
 		return errors.New("unsupported environment or cluster not configured correctly")
@@ -35,7 +39,7 @@ func K8sInstaller(c *k8s.Client) error {
 		fmt.Printf("CRD %s already exists ...\n", hspName)
 	}
 	fmt.Print("Service Account ...\n")
-	if _, err := c.K8sClientset.CoreV1().ServiceAccounts("kube-system").Create(context.Background(), serviceAccount, metav1.CreateOptions{}); err != nil {
+	if _, err := c.K8sClientset.CoreV1().ServiceAccounts(o.Namespace).Create(context.Background(), serviceAccount, metav1.CreateOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			return err
 		}
@@ -49,49 +53,49 @@ func K8sInstaller(c *k8s.Client) error {
 		fmt.Print("Cluster Role Bindings already exists ...\n")
 	}
 	fmt.Print("KubeArmor Relay Service ...\n")
-	if _, err := c.K8sClientset.CoreV1().Services("kube-system").Create(context.Background(), relayService, metav1.CreateOptions{}); err != nil {
+	if _, err := c.K8sClientset.CoreV1().Services(o.Namespace).Create(context.Background(), relayService, metav1.CreateOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			return err
 		}
 		fmt.Print("KubeArmor Relay Service already exists ...\n")
 	}
 	fmt.Print("KubeArmor Relay Deployment ...\n")
-	if _, err := c.K8sClientset.AppsV1().Deployments("kube-system").Create(context.Background(), relayDeployment, metav1.CreateOptions{}); err != nil {
+	if _, err := c.K8sClientset.AppsV1().Deployments(o.Namespace).Create(context.Background(), relayDeployment, metav1.CreateOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			return err
 		}
 		fmt.Print("KubeArmor Relay Deployment already exists ...\n")
 	}
 	fmt.Print("KubeArmor DaemonSet ...\n")
-	if _, err := c.K8sClientset.AppsV1().DaemonSets("kube-system").Create(context.Background(), generateDaemonSet(env), metav1.CreateOptions{}); err != nil {
+	if _, err := c.K8sClientset.AppsV1().DaemonSets(o.Namespace).Create(context.Background(), generateDaemonSet(env), metav1.CreateOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			return err
 		}
 		fmt.Print("KubeArmor DaemonSet already exists ...\n")
 	}
 	fmt.Print("KubeArmor Policy Manager Service ...\n")
-	if _, err := c.K8sClientset.CoreV1().Services("kube-system").Create(context.Background(), policyManagerService, metav1.CreateOptions{}); err != nil {
+	if _, err := c.K8sClientset.CoreV1().Services(o.Namespace).Create(context.Background(), policyManagerService, metav1.CreateOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			return err
 		}
 		fmt.Print("KubeArmor Policy Manager Service already exists ...\n")
 	}
 	fmt.Print("KubeArmor Policy Manager Deployment ...\n")
-	if _, err := c.K8sClientset.AppsV1().Deployments("kube-system").Create(context.Background(), policyManagerDeployment, metav1.CreateOptions{}); err != nil {
+	if _, err := c.K8sClientset.AppsV1().Deployments(o.Namespace).Create(context.Background(), policyManagerDeployment, metav1.CreateOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			return err
 		}
 		fmt.Print("KubeArmor Policy Manager Deployment already exists ...\n")
 	}
 	fmt.Print("KubeArmor Host Policy Manager Service ...\n")
-	if _, err := c.K8sClientset.CoreV1().Services("kube-system").Create(context.Background(), hostPolicyManagerService, metav1.CreateOptions{}); err != nil {
+	if _, err := c.K8sClientset.CoreV1().Services(o.Namespace).Create(context.Background(), hostPolicyManagerService, metav1.CreateOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			return err
 		}
 		fmt.Print("KubeArmor Host Policy Manager Service already exists ...\n")
 	}
 	fmt.Print("KubeArmor Host Policy Manager Deployment ...\n")
-	if _, err := c.K8sClientset.AppsV1().Deployments("kube-system").Create(context.Background(), hostPolicyManagerDeployment, metav1.CreateOptions{}); err != nil {
+	if _, err := c.K8sClientset.AppsV1().Deployments(o.Namespace).Create(context.Background(), hostPolicyManagerDeployment, metav1.CreateOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			return err
 		}
@@ -100,9 +104,9 @@ func K8sInstaller(c *k8s.Client) error {
 	return nil
 }
 
-func K8sUninstaller(c *k8s.Client) error {
+func K8sUninstaller(c *k8s.Client, o Options) error {
 	fmt.Print("Service Account ...\n")
-	if err := c.K8sClientset.CoreV1().ServiceAccounts("kube-system").Delete(context.Background(), serviceAccountName, metav1.DeleteOptions{}); err != nil {
+	if err := c.K8sClientset.CoreV1().ServiceAccounts(o.Namespace).Delete(context.Background(), serviceAccountName, metav1.DeleteOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "not found") {
 			return err
 		}
@@ -116,49 +120,49 @@ func K8sUninstaller(c *k8s.Client) error {
 		fmt.Print("Cluster Role Bindings not found ...\n")
 	}
 	fmt.Print("KubeArmor Relay Service ...\n")
-	if err := c.K8sClientset.CoreV1().Services("kube-system").Delete(context.Background(), relayServiceName, metav1.DeleteOptions{}); err != nil {
+	if err := c.K8sClientset.CoreV1().Services(o.Namespace).Delete(context.Background(), relayServiceName, metav1.DeleteOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "not found") {
 			return err
 		}
 		fmt.Print("KubeArmor Relay Service not found ...\n")
 	}
 	fmt.Print("KubeArmor Relay Deployment ...\n")
-	if err := c.K8sClientset.AppsV1().Deployments("kube-system").Delete(context.Background(), relayDeploymentName, metav1.DeleteOptions{}); err != nil {
+	if err := c.K8sClientset.AppsV1().Deployments(o.Namespace).Delete(context.Background(), relayDeploymentName, metav1.DeleteOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "not found") {
 			return err
 		}
 		fmt.Print("KubeArmor Relay Deployment not found ...\n")
 	}
 	fmt.Print("KubeArmor DaemonSet ...\n")
-	if err := c.K8sClientset.AppsV1().DaemonSets("kube-system").Delete(context.Background(), "kubearmor", metav1.DeleteOptions{}); err != nil {
+	if err := c.K8sClientset.AppsV1().DaemonSets(o.Namespace).Delete(context.Background(), "kubearmor", metav1.DeleteOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "not found") {
 			return err
 		}
 		fmt.Print("KubeArmor DaemonSet not found ...\n")
 	}
 	fmt.Print("KubeArmor Policy Manager Service ...\n")
-	if err := c.K8sClientset.CoreV1().Services("kube-system").Delete(context.Background(), policyManagerServiceName, metav1.DeleteOptions{}); err != nil {
+	if err := c.K8sClientset.CoreV1().Services(o.Namespace).Delete(context.Background(), policyManagerServiceName, metav1.DeleteOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "not found") {
 			return err
 		}
 		fmt.Print("KubeArmor Policy Manager Service not found ...\n")
 	}
 	fmt.Print("KubeArmor Policy Manager Deployment ...\n")
-	if err := c.K8sClientset.AppsV1().Deployments("kube-system").Delete(context.Background(), policyManagerDeploymentName, metav1.DeleteOptions{}); err != nil {
+	if err := c.K8sClientset.AppsV1().Deployments(o.Namespace).Delete(context.Background(), policyManagerDeploymentName, metav1.DeleteOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "not found") {
 			return err
 		}
 		fmt.Print("KubeArmor Policy Manager Deployment not found ...\n")
 	}
 	fmt.Print("KubeArmor Host Policy Manager Service ...\n")
-	if err := c.K8sClientset.CoreV1().Services("kube-system").Delete(context.Background(), hostPolicyManagerServiceName, metav1.DeleteOptions{}); err != nil {
+	if err := c.K8sClientset.CoreV1().Services(o.Namespace).Delete(context.Background(), hostPolicyManagerServiceName, metav1.DeleteOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "not found") {
 			return err
 		}
 		fmt.Print("KubeArmor Host Policy Manager Service not found ...\n")
 	}
 	fmt.Print("KubeArmor Host Policy Manager Deployment ...\n")
-	if err := c.K8sClientset.AppsV1().Deployments("kube-system").Delete(context.Background(), hostPolicyManagerDeploymentName, metav1.DeleteOptions{}); err != nil {
+	if err := c.K8sClientset.AppsV1().Deployments(o.Namespace).Delete(context.Background(), hostPolicyManagerDeploymentName, metav1.DeleteOptions{}); err != nil {
 		if !strings.Contains(err.Error(), "not found") {
 			return err
 		}


### PR DESCRIPTION
Usage:
For installing
`karmor install -n {namespace}`

for uninstalling:
`karmor uninstall -n {namespace}`

I have added namespace flag for uninstall as well although it wasn't specified in the issue https://github.com/kubearmor/kubearmor-client/issues/21. I can remove it if it's not required. 

I have tested this on local kind cluster. 