### PR TITLE
ci: remove windows from release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,6 @@ builds:
     goos:
       - darwin
       - linux
-      - windows
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
recent cilium dep introduced in #45 is causing issues cross compiling for windows, more details in #50. Removing windows build from our releases until the issue is fixed.

Signed-off-by: daemon1024 <barun.acharya@accuknox.com>