### PR TITLE
configure audit posture during installation

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -28,4 +28,5 @@ func init() {
 
 	installCmd.Flags().StringVarP(&installOptions.Namespace, "namespace", "n", "kube-system", "Namespace for resources")
 	installCmd.Flags().StringVarP(&installOptions.KubearmorImage, "image", "i", "kubearmor/kubearmor:stable", "Kubearmor daemonset image to use")
+	installCmd.Flags().StringVarP(&installOptions.Audit, "audit", "a", "", "Kubearmor Audit Posture Context [all,file,network,capabilities]")
 }


### PR DESCRIPTION
Fixes #80 

Usage
```
karmor install --audit=all
karmor install --audit=file
karmor install --audit=file,network
```