### PR TITLE
Add support for crio [Vikas Verma]

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -399,7 +399,7 @@ func autoDetectEnvironment(c *k8s.Client) (name string) {
 		env = "docker"
 		return env
 	}
-	if (runtime == "docker" && semver.Compare(version, "v19.3") >= 0) || runtime == "containerd" {
+	if (runtime == "docker" && semver.Compare(version, "v19.3") >= 0) || runtime == "containerd" || runtime == "cri-o" {
 		env = "generic"
 		return env
 	}


### PR DESCRIPTION
Referencing issue: https://github.com/kubearmor/KubeArmor/issues/221

Added support for cri-o.

Before: Unable to run `karmor install` on openshift due to missing runtime support for `cri-o`
Now: I was able to run `karmor install` successfully without any errors.

Signed-off-by: Vikas Verma <vikasvr23@gmail.com>