### PR TITLE
event channel support

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -56,3 +56,17 @@ jobs:
         uses: morphy2k/revive-action@v2
         with:
           path: "./..."
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: v1.18
+
+      - name: Run unit tests
+        run: make test
+

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ install: build
 clean:
 	cd $(CURDIR); rm -f karmor
 
+.PHONY: test
+test:
+	cd $(CURDIR); go test -v ./...
+
 .PHONY: protobuf
 vm-protobuf:
 	cd $(CURDIR)/vm/protobuf; protoc --proto_path=. --go_opt=paths=source_relative --go_out=plugins=grpc:. vm.proto

--- a/log/log.go
+++ b/log/log.go
@@ -42,6 +42,7 @@ type Options struct {
 	Resource      string
 	Limit         uint32
 	Selector      []string
+	EventChan     chan []byte // channel to send events on
 }
 
 // StopChan Channel
@@ -175,7 +176,7 @@ func StartObserver(o Options) error {
 	close(StopChan)
 
 	logClient.Running = false
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Millisecond * 50)
 
 	// destroy the client
 	if err := logClient.DestroyClient(); err != nil {

--- a/log/logClient.go
+++ b/log/logClient.go
@@ -31,28 +31,28 @@ func StrToFile(str, destFile string) {
 	if _, err := os.Stat(destFile); err != nil {
 		newFile, err := os.Create(filepath.Clean(destFile))
 		if err != nil {
-			fmt.Printf("Failed to create a file (%s, %s)\n", destFile, err.Error())
+			fmt.Fprintf(os.Stderr, "Failed to create a file (%s, %s)\n", destFile, err.Error())
 			return
 		}
 		if err := newFile.Close(); err != nil {
-			fmt.Printf("Failed to close the file (%s, %s)\n", destFile, err.Error())
+			fmt.Fprintf(os.Stderr, "Failed to close the file (%s, %s)\n", destFile, err.Error())
 		}
 	}
 
 	// #nosec
 	file, err := os.OpenFile(destFile, os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		fmt.Printf("Failed to open a file (%s, %s)\n", destFile, err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to open a file (%s, %s)\n", destFile, err.Error())
 	}
 	defer func() {
 		if err := file.Close(); err != nil {
-			fmt.Printf("Failed to close the file (%s, %s)\n", destFile, err.Error())
+			fmt.Fprintf(os.Stderr, "Failed to close the file (%s, %s)\n", destFile, err.Error())
 		}
 	}()
 
 	_, err = file.WriteString(str)
 	if err != nil {
-		fmt.Printf("Failed to write a string into the file (%s, %s)\n", destFile, err.Error())
+		fmt.Fprintf(os.Stderr, "Failed to write a string into the file (%s, %s)\n", destFile, err.Error())
 	}
 }
 
@@ -174,7 +174,7 @@ func (fd *Feeder) WatchMessages(msgPath string, jsonFormat bool) error {
 	for fd.Running {
 		res, err := fd.msgStream.Recv()
 		if err != nil {
-			fmt.Printf("Failed to receive a message (%s)\n", err.Error())
+			fmt.Fprintf(os.Stderr, "Failed to receive a message (%s)\n", err.Error())
 			break
 		}
 
@@ -197,7 +197,7 @@ func (fd *Feeder) WatchMessages(msgPath string, jsonFormat bool) error {
 		}
 	}
 
-	fmt.Println("Stopped WatchMessages")
+	fmt.Fprintln(os.Stderr, "Stopped WatchMessages")
 
 	return nil
 }
@@ -271,11 +271,11 @@ func watchAlertsHelper(res *pb.Alert, o Options) error {
 
 	str := ""
 
-	if o.JSON || o.EventChan != nil {
+	if o.EventChan != nil {
+		o.EventChan <- *res
+	}
+	if o.JSON {
 		arr, _ := json.Marshal(res)
-		if o.EventChan != nil {
-			o.EventChan <- arr
-		}
 		str = fmt.Sprintf("%s\n", string(arr))
 	} else {
 		updatedTime := strings.Replace(res.UpdatedTime, "T", " ", -1)
@@ -343,7 +343,6 @@ func (fd *Feeder) WatchAlerts(o Options) error {
 		for i = 0; i < o.Limit; i++ {
 			res, err := fd.alertStream.Recv()
 			if err != nil {
-				fmt.Printf("Failed to receive an alert (%s)\n", err.Error())
 				break
 			}
 			_ = watchAlertsHelper(res, o)
@@ -355,7 +354,6 @@ func (fd *Feeder) WatchAlerts(o Options) error {
 		for fd.Running {
 			res, err := fd.alertStream.Recv()
 			if err != nil {
-				fmt.Printf("Failed to receive an alert (%s)\n", err.Error())
 				break
 			}
 			_ = watchAlertsHelper(res, o)
@@ -363,7 +361,7 @@ func (fd *Feeder) WatchAlerts(o Options) error {
 		}
 	}
 
-	fmt.Println("Stopped WatchAlerts")
+	fmt.Fprintln(os.Stderr, "Stopped WatchAlerts")
 
 	return nil
 }
@@ -428,11 +426,11 @@ func WatchLogsHelper(res *pb.Log, o Options) error {
 
 	str := ""
 
-	if o.JSON || o.EventChan != nil {
+	if o.EventChan != nil {
+		o.EventChan <- *res
+	}
+	if o.JSON {
 		arr, _ := json.Marshal(res)
-		if o.EventChan != nil {
-			o.EventChan <- arr
-		}
 		str = fmt.Sprintf("%s\n", string(arr))
 	} else {
 		updatedTime := strings.Replace(res.UpdatedTime, "T", " ", -1)
@@ -481,7 +479,6 @@ func (fd *Feeder) WatchLogs(o Options) error {
 		for i = 0; i < o.Limit; i++ {
 			res, err := fd.logStream.Recv()
 			if err != nil {
-				fmt.Printf("Failed to receive an alert (%s)\n", err.Error())
 				break
 			}
 			_ = WatchLogsHelper(res, o)
@@ -491,7 +488,6 @@ func (fd *Feeder) WatchLogs(o Options) error {
 		for fd.Running {
 			res, err := fd.logStream.Recv()
 			if err != nil {
-				fmt.Printf("Failed to receive an alert (%s)\n", err.Error())
 				break
 			}
 			_ = WatchLogsHelper(res, o)
@@ -499,7 +495,7 @@ func (fd *Feeder) WatchLogs(o Options) error {
 		}
 	}
 
-	fmt.Println("Stopped WatchLogs")
+	fmt.Fprintln(os.Stderr, "Stopped WatchLogs")
 
 	return nil
 }

--- a/log/logClient.go
+++ b/log/logClient.go
@@ -192,7 +192,7 @@ func (fd *Feeder) WatchMessages(msgPath string, jsonFormat bool) error {
 
 		if msgPath == "stdout" {
 			fmt.Printf("%s", str)
-		} else {
+		} else if msgPath != "" {
 			StrToFile(str, msgPath)
 		}
 	}
@@ -271,8 +271,11 @@ func watchAlertsHelper(res *pb.Alert, o Options) error {
 
 	str := ""
 
-	if o.JSON {
+	if o.JSON || o.EventChan != nil {
 		arr, _ := json.Marshal(res)
+		if o.EventChan != nil {
+			o.EventChan <- arr
+		}
 		str = fmt.Sprintf("%s\n", string(arr))
 	} else {
 		updatedTime := strings.Replace(res.UpdatedTime, "T", " ", -1)
@@ -325,7 +328,7 @@ func watchAlertsHelper(res *pb.Alert, o Options) error {
 
 	if o.LogPath == "stdout" {
 		fmt.Printf("%s", str)
-	} else {
+	} else if o.LogPath != "" {
 		StrToFile(str, o.LogPath)
 	}
 	return nil
@@ -425,8 +428,11 @@ func WatchLogsHelper(res *pb.Log, o Options) error {
 
 	str := ""
 
-	if o.JSON {
+	if o.JSON || o.EventChan != nil {
 		arr, _ := json.Marshal(res)
+		if o.EventChan != nil {
+			o.EventChan <- arr
+		}
 		str = fmt.Sprintf("%s\n", string(arr))
 	} else {
 		updatedTime := strings.Replace(res.UpdatedTime, "T", " ", -1)
@@ -459,7 +465,7 @@ func WatchLogsHelper(res *pb.Log, o Options) error {
 
 	if o.LogPath == "stdout" {
 		fmt.Printf("%s", str)
-	} else {
+	} else if o.LogPath != "" {
 		StrToFile(str, o.LogPath)
 	}
 	return nil

--- a/log/logClient_test.go
+++ b/log/logClient_test.go
@@ -1,0 +1,52 @@
+package log
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	pb "github.com/kubearmor/KubeArmor/protobuf"
+)
+
+var eventChan chan []byte
+var gotEvent = false
+
+const maxEvents = 5
+
+func waitOnEvent(cnt int) {
+	for i := 0; i < cnt; i++ {
+		evt := <-eventChan
+		fmt.Printf("Event: %s\n", string(evt))
+	}
+	gotEvent = true
+}
+
+func TestLogClient(t *testing.T) {
+	var res = pb.Alert{
+		ClusterName:    "breaking-bad",
+		HostName:       "saymyname",
+		NamespaceName:  "heisenberg",
+		PodName:        "new-mexico",
+		Labels:         "substance=meth,currency=usd",
+		ContainerID:    "12345678901234567890",
+		ContainerName:  "los-polos",
+		ContainerImage: "evergreen",
+	}
+	eventChan = make(chan []byte, maxEvents)
+	var o = Options{
+		EventChan: eventChan,
+	}
+	for i := 0; i < maxEvents; i++ {
+		err := watchAlertsHelper(&res, o)
+		if err != nil {
+			t.Errorf("watchAlertsHelper failed\n")
+		}
+	}
+	go waitOnEvent(maxEvents)
+	for i := 0; i < 10 && !gotEvent; i++ {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !gotEvent {
+		t.Errorf("did not receive the event")
+	}
+}


### PR DESCRIPTION
External tools might want to handle events as and when they arrive.
Currently, karmor simply prints the events to stdout. Now the API is
added support to export the events on a channel to external tool. Needed
this for kubearmor auto test framework.

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>