### PR TITLE
Add cri-o in environment for karmor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/kubearmor/KVMService/src/types v0.0.0-20220619161146-0f42a61893bc
 	github.com/kubearmor/KubeArmor/KubeArmor v0.0.0-20220620050120-7e1810d2ad41
-	github.com/kubearmor/KubeArmor/deployments v0.0.0-20220706172948-9d2644f2666b
+	github.com/kubearmor/KubeArmor/deployments v0.0.0-20220713111330-5ede97c62720
 	github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy v0.0.0-20220620050120-7e1810d2ad41
 	github.com/kubearmor/KubeArmor/pkg/KubeArmorPolicy v0.0.0-20220620050120-7e1810d2ad41
 	github.com/kubearmor/KubeArmor/protobuf v0.0.0-20220620050120-7e1810d2ad41

--- a/go.sum
+++ b/go.sum
@@ -856,8 +856,8 @@ github.com/kubearmor/KVMService/src/types v0.0.0-20220619161146-0f42a61893bc h1:
 github.com/kubearmor/KVMService/src/types v0.0.0-20220619161146-0f42a61893bc/go.mod h1:jH95bvc6gzdHxVdyUAx/MM9q27P9EPQUl13HkBO5mr4=
 github.com/kubearmor/KubeArmor/KubeArmor v0.0.0-20220620050120-7e1810d2ad41 h1:JcYB5FBXQC25LYERpVPIiKAe+Yqi5ajE6Nhlzdt+L3w=
 github.com/kubearmor/KubeArmor/KubeArmor v0.0.0-20220620050120-7e1810d2ad41/go.mod h1:PS5U+aErr2Phj1RqOjdQaIcCFaNCNNVk/AzMacvOg0Q=
-github.com/kubearmor/KubeArmor/deployments v0.0.0-20220706172948-9d2644f2666b h1:prbwatIC08aeULQd+71mGNSROAnKBt4Z/OLzarcdMP4=
-github.com/kubearmor/KubeArmor/deployments v0.0.0-20220706172948-9d2644f2666b/go.mod h1:cyEhgwG/sKmC6OI0Jgx+4T6/G7YiafcX2OpgSsbZ+b8=
+github.com/kubearmor/KubeArmor/deployments v0.0.0-20220713111330-5ede97c62720 h1:O3V9T42/3rsu8o4TzeHPqxBr0hxA5bUGFoYN+HZ3ygc=
+github.com/kubearmor/KubeArmor/deployments v0.0.0-20220713111330-5ede97c62720/go.mod h1:cyEhgwG/sKmC6OI0Jgx+4T6/G7YiafcX2OpgSsbZ+b8=
 github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy v0.0.0-20220620050120-7e1810d2ad41 h1:qlcrgrK4NAD1tIatGKUgsZUh/TfLXdLfyNwS7wbnKF0=
 github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy v0.0.0-20220620050120-7e1810d2ad41/go.mod h1:ihWxQRuta8kGodG9NP4va/s8Se4ZY59yjZVeB/NahMo=
 github.com/kubearmor/KubeArmor/pkg/KubeArmorPolicy v0.0.0-20220620050120-7e1810d2ad41 h1:UUe18MML5aPkQUki97K7mdnWofNYHNOJw65FJ/pK1lI=

--- a/install/install.go
+++ b/install/install.go
@@ -404,6 +404,12 @@ func autoDetectEnvironment(c *k8s.Client) (name string) {
 		env = "docker"
 		return env
 	}
+
+	if runtime == "cri-o" {
+		env = "oke"
+		return env
+	}
+
 	if (runtime == "docker" && semver.Compare(version, "v19.3") >= 0) || runtime == "containerd" {
 		env = "generic"
 		return env


### PR DESCRIPTION
This Pull requests adds env for cri-o
Reference Issue: https://github.com/kubearmor/KubeArmor/issues/221

After installing, following doc to test sample policy:
```
POD_NAME=$(kubectl get pods -n multiubuntu -l "group=group-1,container=ubuntu-1" -o jsonpath='{.items[0].metadata.name}') && kubectl -n multiubuntu exec -it $POD_NAME -- bash

groups: cannot find name for group ID 1000640000
1000640000@ubuntu-1-deployment-5bd4dff469-d4qjl:/$ sleep 1
```
It did went to sleep for 1 second, but in logs I saw:
```
Severity: 5
Message: block /bin/sleep
Type: MatchedPolicy
Source: /bin/bash
Operation: Process
Resource: /bin/sleep 4
Data: syscall=SYS_EXECVE
Action: Audit (Block)
Result: Passed
```
Supporting Pull request to provide required volume mounts for daemon set [here](https://github.com/kubearmor/KubeArmor/pull/761)
Signed-off-by: Vikas Verma [vikasvr23@gmail.com](mailto:vikasvr23@gmail.com)