### PR TITLE
sysdump output file

### DIFF
--- a/cmd/sysdump.go
+++ b/cmd/sysdump.go
@@ -8,13 +8,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var dumpOptions sysdump.Options
+
 // sysdumpCmd represents the get command
 var sysdumpCmd = &cobra.Command{
 	Use:   "sysdump",
 	Short: "Collect system dump information for troubleshooting and error report",
 	Long:  `Collect system dump information for troubleshooting and error reports`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := sysdump.Collect(client); err != nil {
+		if err := sysdump.Collect(client, dumpOptions); err != nil {
 			return err
 		}
 		return nil
@@ -23,4 +25,5 @@ var sysdumpCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(sysdumpCmd)
+	sysdumpCmd.Flags().StringVarP(&dumpOptions.Filename, "file", "f", "", "output file to use")
 }

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -25,8 +26,13 @@ import (
 	"github.com/mholt/archiver/v3"
 )
 
+// Options options for sysdump
+type Options struct {
+	Filename string
+}
+
 // Collect Function
-func Collect(c *k8s.Client) error {
+func Collect(c *k8s.Client, o Options) error {
 	var errs errgroup.Group
 
 	d, err := os.MkdirTemp("", "karmor-sysdump")
@@ -176,7 +182,12 @@ func Collect(c *k8s.Client) error {
 		return dumpError
 	}
 
-	sysdumpFile := "karmor-sysdump-" + time.Now().Format(time.UnixDate) + ".zip"
+	sysdumpFile := ""
+	if o.Filename == "" {
+		sysdumpFile = "karmor-sysdump-" + strings.Replace(time.Now().Format(time.UnixDate), ":", "_", -1) + ".zip"
+	} else {
+		sysdumpFile = o.Filename
+	}
 
 	if err := archiver.Archive([]string{d}, sysdumpFile); err != nil {
 		return fmt.Errorf("failed to create zip file: %w", err)


### PR DESCRIPTION
* certain platforms do not allow colons to be part of filename (faced
  problem on GH action while uploading artifacts)
* ability to explicitly specify output file name

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>