### PR TITLE
install: Add flag to just save manifest and not install

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -29,4 +29,6 @@ func init() {
 	installCmd.Flags().StringVarP(&installOptions.Namespace, "namespace", "n", "kube-system", "Namespace for resources")
 	installCmd.Flags().StringVarP(&installOptions.KubearmorImage, "image", "i", "kubearmor/kubearmor:stable", "Kubearmor daemonset image to use")
 	installCmd.Flags().StringVarP(&installOptions.Audit, "audit", "a", "", "Kubearmor Audit Posture Context [all,file,network,capabilities]")
+	installCmd.Flags().BoolVar(&installOptions.Save, "save", false, "Save KubeArmor Manifest ")
+
 }

--- a/go.sum
+++ b/go.sum
@@ -856,8 +856,6 @@ github.com/kubearmor/KVMService/src/types v0.0.0-20220619161146-0f42a61893bc h1:
 github.com/kubearmor/KVMService/src/types v0.0.0-20220619161146-0f42a61893bc/go.mod h1:jH95bvc6gzdHxVdyUAx/MM9q27P9EPQUl13HkBO5mr4=
 github.com/kubearmor/KubeArmor/KubeArmor v0.0.0-20220620050120-7e1810d2ad41 h1:JcYB5FBXQC25LYERpVPIiKAe+Yqi5ajE6Nhlzdt+L3w=
 github.com/kubearmor/KubeArmor/KubeArmor v0.0.0-20220620050120-7e1810d2ad41/go.mod h1:PS5U+aErr2Phj1RqOjdQaIcCFaNCNNVk/AzMacvOg0Q=
-github.com/kubearmor/KubeArmor/deployments v0.0.0-20220720093554-d6fef36897a7 h1:ynscEa4oZBB0ek4+Z5jI/DFDIR3Ts0ybTBYDhWyXLXY=
-github.com/kubearmor/KubeArmor/deployments v0.0.0-20220720093554-d6fef36897a7/go.mod h1:cyEhgwG/sKmC6OI0Jgx+4T6/G7YiafcX2OpgSsbZ+b8=
 github.com/kubearmor/KubeArmor/deployments v0.0.0-20220728032827-8078616fc8bd h1:uymKe8q/w3Q1KKHiO1lBh+ioYFZWeM0uyIsz5b9UNDU=
 github.com/kubearmor/KubeArmor/deployments v0.0.0-20220728032827-8078616fc8bd/go.mod h1:cyEhgwG/sKmC6OI0Jgx+4T6/G7YiafcX2OpgSsbZ+b8=
 github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy v0.0.0-20220620050120-7e1810d2ad41 h1:qlcrgrK4NAD1tIatGKUgsZUh/TfLXdLfyNwS7wbnKF0=

--- a/install/customResource.go
+++ b/install/customResource.go
@@ -4,22 +4,16 @@
 package install
 
 import (
-	"context"
-	"fmt"
-
 	hsp "github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy/crd"
 	ksp "github.com/kubearmor/KubeArmor/pkg/KubeArmorPolicy/crd"
-	"github.com/kubearmor/kubearmor-client/k8s"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var kspName = "kubearmorpolicies.security.kubearmor.com"
 var hspName = "kubearmorhostpolicies.security.kubearmor.com"
 
 // CreateCustomResourceDefinition creates the CRD and add it into Kubernetes.
-func CreateCustomResourceDefinition(c *k8s.Client, crdName string) (*apiextensions.CustomResourceDefinition, error) {
+func CreateCustomResourceDefinition(crdName string) apiextensions.CustomResourceDefinition {
 	var crd apiextensions.CustomResourceDefinition
 	switch crdName {
 	case kspName:
@@ -27,13 +21,6 @@ func CreateCustomResourceDefinition(c *k8s.Client, crdName string) (*apiextensio
 	case hspName:
 		crd = hsp.GetCRD()
 	}
-	_, err := c.APIextClientset.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), &crd, metav1.CreateOptions{})
-	if err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			return nil, fmt.Errorf("CRD %s already exists %+v", crdName, err)
-		}
-		return nil, fmt.Errorf("failed to create CRD %s: %+v", crdName, err)
-	}
 
-	return &crd, nil
+	return crd
 }


### PR DESCRIPTION
New flag to save the KubeArmor Manifest file for the cluster env without installing
Also fixed panic when Nodes aren't available for environment detection

Related #109 