### PR TITLE
fix: blank policy check

### DIFF
--- a/vm/policy.go
+++ b/vm/policy.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -121,7 +122,8 @@ func PolicyHandling(t string, path string, o PolicyOptions, httpAddress string, 
 	policies := strings.Split(string(policyFile), "---")
 
 	for _, policy := range policies {
-		if policy == "" {
+
+		if matched, _ := regexp.MatchString("^\\s*$", policy); matched {
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: slayer321 <sachin.maurya7666@gmail.com>

Add check for the manifest file after the separator (---)  if there is a blank .

fixed [#769](https://github.com/kubearmor/KubeArmor/issues/769)