### PR TITLE
probe: update kernel header check

### DIFF
--- a/deployment/probedeployment.go
+++ b/deployment/probedeployment.go
@@ -15,7 +15,7 @@ import (
 var Karmorprobe = "karmor-probe"
 
 // GenerateDaemonSet Function
-func GenerateDaemonSet(namespace string) *appsv1.DaemonSet {
+func GenerateDaemonSet(namespace string, krnhdr bool) *appsv1.DaemonSet {
 
 	var label = map[string]string{
 		"kubearmor-app": Karmorprobe,
@@ -32,11 +32,6 @@ func GenerateDaemonSet(namespace string) *appsv1.DaemonSet {
 			MountPath: "/sys/kernel/security",
 			ReadOnly:  true,
 		},
-		{
-			Name:      "kernel-header", //kernel header (read-only)
-			MountPath: "/usr/src",
-			ReadOnly:  true,
-		},
 	}
 
 	var volumes = []corev1.Volume{
@@ -48,14 +43,39 @@ func GenerateDaemonSet(namespace string) *appsv1.DaemonSet {
 				},
 			},
 		},
-		{
-			Name: "kernel-header",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/usr/src",
+	}
+
+	if krnhdr {
+		volumeMounts = append(volumeMounts, []corev1.VolumeMount{
+			{
+				Name:      "lib-modules", //lib modules (read-only)
+				MountPath: "/lib/modules",
+				ReadOnly:  true,
+			},
+			{
+				Name:      "kernel-header", //kernel header (read-only)
+				MountPath: "/usr/src",
+				ReadOnly:  true,
+			},
+		}...)
+		volumes = append(volumes, []corev1.Volume{
+			{
+				Name: "lib-modules",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/lib/modules",
+					},
 				},
 			},
-		},
+			{
+				Name: "kernel-header",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/usr/src",
+					},
+				},
+			},
+		}...)
 	}
 
 	return &appsv1.DaemonSet{

--- a/go.sum
+++ b/go.sum
@@ -702,8 +702,6 @@ github.com/kubearmor/KVMService/src/types v0.0.0-20220714130113-b0eba8c9ff34 h1:
 github.com/kubearmor/KVMService/src/types v0.0.0-20220714130113-b0eba8c9ff34/go.mod h1:jH95bvc6gzdHxVdyUAx/MM9q27P9EPQUl13HkBO5mr4=
 github.com/kubearmor/KubeArmor/KubeArmor v0.0.0-20220815044951-425f333210e1 h1:AO1TIcEDCQFIN9fEls5bTwM86/7/5kiLpZ8wEkNYiRU=
 github.com/kubearmor/KubeArmor/KubeArmor v0.0.0-20220815044951-425f333210e1/go.mod h1:eZsn+ZbHGi1e/rIJW7IwYFvOJv8S2YekphskoBcUVOI=
-github.com/kubearmor/KubeArmor/deployments v0.0.0-20220830040101-f657b0146f88 h1:d/mVwYq2jz+6EqjiBLNVbFbUD7qcA+JrhNqNQk9xaeo=
-github.com/kubearmor/KubeArmor/deployments v0.0.0-20220830040101-f657b0146f88/go.mod h1:MIcoFMLGKjXSxwSIhBaLbp1aYItmNMI2podNwc30bug=
 github.com/kubearmor/KubeArmor/deployments v0.0.0-20220902110926-23f39cfa09e5 h1:Z8bcwblMpPRhL3R/4STE8NktiyOyyEW83uynikZZvJ8=
 github.com/kubearmor/KubeArmor/deployments v0.0.0-20220902110926-23f39cfa09e5/go.mod h1:MIcoFMLGKjXSxwSIhBaLbp1aYItmNMI2podNwc30bug=
 github.com/kubearmor/KubeArmor/pkg/KubeArmorHostPolicy v0.0.0-20220620050120-7e1810d2ad41 h1:qlcrgrK4NAD1tIatGKUgsZUh/TfLXdLfyNwS7wbnKF0=


### PR DESCRIPTION
- We now check for either BTF Information or Kernel Headers.
- recreate the daemonset without relevant mounts  if error while mounting kernel headers probe
- refactored exec into pod logic