### PR TITLE
recommend runtime policy using karmor

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -115,10 +115,6 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/accuknox/auto-policy-discovery/src v0.0.0-20220906112453-a79685a5de25 h1:qKWzxf5lfdu26m1zh6f5uskkxxmsjFw40vMBFq/7QCo=
-github.com/accuknox/auto-policy-discovery/src v0.0.0-20220906112453-a79685a5de25/go.mod h1:R5eU8iW3k7lPwrycZ0zpe4s0X76IpjJxpHCkSyd7CpY=
-github.com/accuknox/auto-policy-discovery/src v0.0.0-20220908062018-731641ea2a8d h1:47SNjljio848XPh4E59WzIYGUIi36TjrI9ZurR4dslg=
-github.com/accuknox/auto-policy-discovery/src v0.0.0-20220908062018-731641ea2a8d/go.mod h1:R5eU8iW3k7lPwrycZ0zpe4s0X76IpjJxpHCkSyd7CpY=
 github.com/accuknox/auto-policy-discovery/src v0.0.0-20220909105533-27ee0d74dfc3 h1:VvViB+GBBoQpUZCveX2l+wmJ4buwKZjKsYpcQoGArsk=
 github.com/accuknox/auto-policy-discovery/src v0.0.0-20220909105533-27ee0d74dfc3/go.mod h1:R5eU8iW3k7lPwrycZ0zpe4s0X76IpjJxpHCkSyd7CpY=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=

--- a/recommend/imageHandler.go
+++ b/recommend/imageHandler.go
@@ -408,6 +408,7 @@ func getImageDetails(namespace, deployment string, labels LabelMap, imageName st
 
 	// step 4: get policy from image info
 	img.getPolicyFromImageInfo()
+
 	return nil
 }
 

--- a/recommend/policyRules.go
+++ b/recommend/policyRules.go
@@ -39,7 +39,7 @@ type Description struct {
 
 // SysRule specifics a file/process rule. Note that if the Path ends in "/" it is considered to be Directory rule
 type SysRule struct {
-	FromSource string   `json:"fromSource" yaml:"fromSource"`
+	FromSource []string `json:"fromSource" yaml:"fromSource"`
 	Path       []string `json:"path" yaml:"path"`
 	Recursive  bool     `json:"recursive" yaml:"recursive"`
 	OwnerOnly  bool     `json:"ownerOnly" yaml:"ownerOnly"`

--- a/recommend/recommend.go
+++ b/recommend/recommend.go
@@ -106,7 +106,8 @@ func Recommend(c *k8s.Client, o Options) error {
 			return err
 		}
 		for _, dp := range dps.Items {
-			if matchLabels(labelMap, dp.Spec.Selector.MatchLabels) {
+
+			if matchLabels(labelMap, dp.Spec.Template.Labels) {
 				images := []string{}
 				for _, container := range dp.Spec.Template.Spec.Containers {
 					images = append(images, container.Image)
@@ -115,7 +116,7 @@ func Recommend(c *k8s.Client, o Options) error {
 				deployments = append(deployments, Deployment{
 					Name:      dp.Name,
 					Namespace: dp.Namespace,
-					Labels:    dp.Spec.Selector.MatchLabels,
+					Labels:    dp.Spec.Template.Labels,
 					Images:    images,
 				})
 			}
@@ -144,6 +145,7 @@ func Recommend(c *k8s.Client, o Options) error {
 }
 
 func handleDeployment(dp Deployment) error {
+
 	var err error
 	for _, img := range dp.Images {
 		tempDir, err = os.MkdirTemp("", "karmor")

--- a/recommend/runtimePolicy.go
+++ b/recommend/runtimePolicy.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Authors of KubeArmor
+
+package recommend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	opb "github.com/accuknox/auto-policy-discovery/src/protobuf/v1/observability"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var saPath []string
+
+func init() {
+	saPath = []string{
+		"/var/run/secrets/kubernetes.io/serviceaccount/",
+		"/run/secrets/kubernetes.io/serviceaccount/",
+	}
+}
+
+// createRuntimePolicy function generates runtime policy for service account
+func createRuntimePolicy(img *ImageInfo) error {
+	var labels string
+	for key, value := range img.Labels {
+		labels = strings.TrimPrefix(fmt.Sprintf("%s,%s=%s", labels, key, value), ",")
+	}
+	gRPC := ""
+	if val, ok := os.LookupEnv("DISCOVERY_SERVICE"); ok {
+		gRPC = val
+	} else {
+		gRPC = "localhost:9089"
+	}
+	// create a client
+	conn, err := grpc.Dial(gRPC, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return errors.New("could not connect to the server. Possible troubleshooting:\n- Check if discovery engine is running\n- Create a portforward to discovery engine service using\n\t\033[1mkubectl port-forward -n explorer service/knoxautopolicy --address 0.0.0.0 --address :: 9089:9089\033[0m\n[0m")
+	}
+	defer conn.Close()
+	client := opb.NewObservabilityClient(conn)
+	podData, err := client.GetPodNames(context.Background(), &opb.Request{
+		Label:     labels,
+		NameSpace: img.Namespace,
+	})
+	if err != nil {
+		return err
+	}
+	var resp *opb.Response
+	var sumResp []*opb.Response
+	for _, pod := range podData.PodName {
+		resp, err = client.Summary(context.Background(), &opb.Request{
+			PodName:   pod,
+			Label:     labels,
+			NameSpace: img.Namespace,
+			Type:      "file",
+		})
+		if err != nil {
+			return err
+		}
+		sumResp = append(sumResp, resp)
+	}
+
+	ms, err := checkProcessFileData(sumResp)
+	if err != nil {
+		return err
+	}
+	img.writePolicyFile(ms)
+	return nil
+}
+
+func checkProcessFileData(sumResp []*opb.Response) (MatchSpec, error) {
+	var filePaths SysRule
+	ms := MatchSpec{}
+	ms.OnEvent.Severity = 1
+	ms.Description.Tldr = "Kubernetes serviceaccount folder access should be limited "
+	ms.Name = "audit-serviceaccount-runtime"
+	ms.OnEvent.Tags = []string{"KUBERNETES", "SERVICE ACCOUNT", "RUNTIME POLICY"}
+	ms.OnEvent.Message = "serviceaccount access detected"
+	ms.OnEvent.Action = "Audit"
+	for _, eachResp := range sumResp {
+		for _, fileData := range eachResp.FileData {
+			if strings.HasPrefix(fileData.ProcName, saPath[0]) || strings.HasPrefix(fileData.ProcName, saPath[1]) {
+				filePaths.FromSource = append(filePaths.FromSource, fileData.ParentProcName)
+			}
+		}
+	}
+	filePaths.Path = saPath
+	filePaths.Recursive = true
+
+	ms.Rules = Rules{
+		FileRule: &filePaths,
+	}
+	return ms, nil
+}


### PR DESCRIPTION
- Added the ability to query the discovery engine to get summary details
- Added the ability to create dynamic policy based on k8s service account access data from the discovery engine
- Added support for the creation of a single policy with multiple rules
- Optimised the function to include details of generated policies on the report file

Addresses https://github.com/kubearmor/kubearmor-client/issues/112#issuecomment-1216476912

Signed-off-by: vishnusomank <vishnu@accuknox.com>