### PR TITLE
[karmor summary] sorting of source in file/process data

### DIFF
--- a/summary/table.go
+++ b/summary/table.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"sort"
 	"strings"
 
 	opb "github.com/accuknox/auto-policy-discovery/src/protobuf/v1/observability"
@@ -43,6 +44,15 @@ func DisplaySummaryOutput(resp *opb.Response, revDNSLookup bool, requestType str
 				procStrSlice = append(procStrSlice, procData.Status)
 				procRowData = append(procRowData, procStrSlice)
 			}
+			sort.Slice(procRowData[:], func(i, j int) bool {
+				for x := range procRowData[i] {
+					if procRowData[i][x] == procRowData[j][x] {
+						continue
+					}
+					return procRowData[i][x] < procRowData[j][x]
+				}
+				return false
+			})
 			WriteTable(SysProcHeader, procRowData)
 			fmt.Printf("\n")
 		}
@@ -62,6 +72,15 @@ func DisplaySummaryOutput(resp *opb.Response, revDNSLookup bool, requestType str
 				fileStrSlice = append(fileStrSlice, fileData.Status)
 				fileRowData = append(fileRowData, fileStrSlice)
 			}
+			sort.Slice(fileRowData[:], func(i, j int) bool {
+				for x := range fileRowData[i] {
+					if fileRowData[i][x] == fileRowData[j][x] {
+						continue
+					}
+					return fileRowData[i][x] < fileRowData[j][x]
+				}
+				return false
+			})
 			WriteTable(SysFileHeader, fileRowData)
 			fmt.Printf("\n")
 		}


### PR DESCRIPTION
added sorting for the `karmor summary` command's file and process data
Here is the sample output of sorted data:
```
File Data
+-----------------------------------+---------------------------------------------------------------------+-------+------------------------------+--------+
|            SRC PROCESS            |                        DESTINATION FILE PATH                        | COUNT |      LAST UPDATED TIME       | STATUS |
+-----------------------------------+---------------------------------------------------------------------+-------+------------------------------+--------+
| /bin/bash                         | /var/www/html                                                       | 1     | Thu Oct  6 09:26:08 IST 2022 | Allow  |
| /bin/bash                         | /var/www/html/.htaccess                                             | 1     | Thu Oct  6 09:26:08 IST 2022 | Allow  |
| /bin/cat                          | /etc/ld.so.cache                                                    | 1     | Thu Oct  6 09:26:03 IST 2022 | Allow  |
| /bin/cat                          | /lib/x86_64-linux-gnu/libc-2.19.so                                  | 1     | Thu Oct  6 09:26:08 IST 2022 | Allow  |
| /bin/cat                          | /tmp/sh-thd-146085024                                               | 1     | Thu Oct  6 09:26:04 IST 2022 | Allow  |
| /bin/chown                        | /etc/ld.so.cache                                                    | 1     | Thu Oct  6 09:25:59 IST 2022 | Allow  |
| /bin/chown                        | /etc/ld.so.cache                                                    | 1     | Thu Oct  6 09:25:59 IST 2022 | Allow  |
| /bin/chown                        | /etc/passwd                                                         | 1     | Thu Oct  6 09:26:10 IST 2022 | Allow  |
| /bin/chown                        | /lib/x86_64-linux-gnu/libnss_files-2.19.so                          | 1     | Thu Oct  6 09:26:08 IST 2022 | Allow  |
| /bin/chown                        | /lib/x86_64-linux-gnu/libnss_nis-2.19.so                            | 2     | Thu Oct  6 09:26:16 IST 2022 | Allow  |
| /bin/dash                         | /etc/ld.so.cache                                                    | 1     | Thu Oct  6 09:26:17 IST 2022 | Allow  |
| /bin/dash                         | /lib/x86_64-linux-gnu/libc-2.19.so                                  | 1     | Thu Oct  6 09:25:59 IST 2022 | Allow  |
| /bin/mkdir                        | /etc/ld.so.cache                                                    | 2     | Thu Oct  6 09:28:02 IST 2022 | Allow  |
| /bin/mkdir                        | /lib/x86_64-linux-gnu/libc-2.19.so                                  | 1     | Thu Oct  6 09:28:03 IST 2022 | Allow  |
| /bin/mkdir                        | /lib/x86_64-linux-gnu/libdl-2.19.so                                 | 1     | Thu Oct  6 09:28:03 IST 2022 | Allow  |
| /bin/mkdir                        | /lib/x86_64-linux-gnu/libpcre.so.3.13.1                             | 1     | Thu Oct  6 09:27:59 IST 2022 | Allow  |
| /bin/mkdir                        | /lib/x86_64-linux-gnu/libpthread-2.19.so                            | 2     | Thu Oct  6 09:28:03 IST 2022 | Allow  |
```