### PR TITLE
[Enhancement] karmor recommend to pull private registries

### DIFF
--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -49,4 +49,5 @@ func init() {
 	recommendCmd.Flags().StringVarP(&recommendOptions.OutDir, "outdir", "o", "out", "output folder to write policies")
 	recommendCmd.Flags().StringVarP(&recommendOptions.ReportFile, "report", "r", "report.txt", "report file")
 	recommendCmd.Flags().StringSliceVarP(&recommendOptions.Tags, "tag", "t", []string{}, "tags (comma-separated) to apply. Eg. PCI-DSS, MITRE")
+	recommendCmd.Flags().StringVarP(&recommendOptions.Config, "config", "c", recommend.UserHome()+"/.docker/config.json", "absolute path to image registry configuration file")
 }

--- a/recommend/imageHandler.go
+++ b/recommend/imageHandler.go
@@ -29,8 +29,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var cli *client.Client // docker client
-var tempDir string     // temporary directory used by karmor to save image etc
+var cli *client.Client      // docker client
+var tempDir string          // temporary directory used by karmor to save image etc
+var dockerConfigPath string // stores path of docker config.json
 
 // ImageInfo contains image information
 type ImageInfo struct {
@@ -46,9 +47,28 @@ type ImageInfo struct {
 	Labels     LabelMap
 }
 
-func getAuthStr() string {
-	u := os.Getenv("DOCKER_USERNAME")
-	p := os.Getenv("DOCKER_PASSWORD")
+// AuthConfigurations contains the configuration information's
+type AuthConfigurations struct {
+	Configs map[string]types.AuthConfig `json:"configs"`
+}
+
+// getConf reads the docker config.json file and returns a map
+func getConf() map[string]types.AuthConfig {
+	var confs map[string]types.AuthConfig
+	if dockerConfigPath != "" {
+		data, err := os.ReadFile(filepath.Clean(dockerConfigPath))
+		if err != nil {
+			return confs
+		}
+		confs, err = parseDockerConfig(data)
+		if err != nil {
+			return confs
+		}
+	}
+	return confs
+}
+
+func getAuthStr(u, p string) string {
 	if u == "" || p == "" {
 		return ""
 	}
@@ -75,13 +95,50 @@ func init() {
 	}
 }
 
+// parseDockerConfig parses the docker config.json to generate a map
+func parseDockerConfig(byteData []byte) (map[string]types.AuthConfig, error) {
+
+	confsWrapper := struct {
+		Auths map[string]types.AuthConfig `json:"auths"`
+	}{}
+	if err := json.Unmarshal(byteData, &confsWrapper); err == nil {
+		if len(confsWrapper.Auths) > 0 {
+			return confsWrapper.Auths, nil
+		}
+	}
+
+	var confs map[string]types.AuthConfig
+	if err := json.Unmarshal(byteData, &confs); err != nil {
+		return nil, err
+	}
+	return confs, nil
+}
+
 func pullImage(imageName string) error {
-	out, err := cli.ImagePull(context.Background(), imageName, types.ImagePullOptions{RegistryAuth: getAuthStr()})
+	var out io.ReadCloser
+	var err error
+	var confData []string
+	confData = append(confData, fmt.Sprintf("%s:%s", os.Getenv("DOCKER_USERNAME"), os.Getenv("DOCKER_PASSWORD")))
+	if dockerConfigPath != "" {
+		confs := getConf()
+		if len(confs) > 0 {
+			for _, conf := range confs {
+				data, _ := base64.StdEncoding.DecodeString(conf.Auth)
+				confData = append(confData, string(data))
+			}
+		}
+	}
+	for _, data := range confData {
+		userpass := strings.SplitN(string(data), ":", 2)
+		out, err = cli.ImagePull(context.Background(), imageName, types.ImagePullOptions{RegistryAuth: getAuthStr(userpass[0], userpass[1])})
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
-		log.WithError(err).Fatal("could not pull image")
+		log.WithError(err).Fatal("could not pull images using ", dockerConfigPath)
 	}
 	defer out.Close()
-
 	termFd, isTerm := term.GetFdInfo(os.Stderr)
 	err = jsonmessage.DisplayJSONMessagesStream(out, os.Stderr, termFd, isTerm, nil)
 	if err != nil {
@@ -423,7 +480,8 @@ func getImageDetails(namespace, deployment string, labels LabelMap, imageName st
 	return nil
 }
 
-func imageHandler(namespace, deployment string, labels LabelMap, imageName string) error {
+func imageHandler(namespace, deployment string, labels LabelMap, imageName string, config string) error {
+	dockerConfigPath = config
 	log.WithFields(log.Fields{
 		"image": imageName,
 	}).Info("pulling image")

--- a/recommend/policyTemplates.go
+++ b/recommend/policyTemplates.go
@@ -34,13 +34,13 @@ var CurrentVersion string
 var LatestVersion string
 
 func getCachePath() string {
-	cache := fmt.Sprintf("%s/%s", userHome(), cache)
+	cache := fmt.Sprintf("%s/%s", UserHome(), cache)
 	return cache
 
 }
 
-// userHome function returns users home directory
-func userHome() string {
+// UserHome function returns users home directory
+func UserHome() string {
 	if runtime.GOOS == "windows" {
 		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
 		if home == "" {

--- a/recommend/recommend.go
+++ b/recommend/recommend.go
@@ -25,6 +25,7 @@ type Options struct {
 	Namespace  string
 	OutDir     string
 	ReportFile string
+	Config     string
 }
 
 // LabelMap is an alias for map[string]string
@@ -155,7 +156,7 @@ func handleDeployment(dp Deployment) error {
 		if err != nil {
 			log.WithError(err).Error("could not create temp dir")
 		}
-		err = imageHandler(dp.Namespace, dp.Name, dp.Labels, img)
+		err = imageHandler(dp.Namespace, dp.Name, dp.Labels, img, options.Config)
 		if err != nil {
 			log.WithError(err).WithFields(log.Fields{
 				"image": img,

--- a/recommend/report_html.go
+++ b/recommend/report_html.go
@@ -118,7 +118,7 @@ func (r HTMLReport) Start(img *ImageInfo) error {
 		ImgInfo: []Info{
 			{Key: "Container", Val: img.RepoTags[0]},
 			{Key: "OS/Arch/Distro", Val: img.OS + "/" + img.Arch + "/" + img.Distro},
-			{Key: "Output Directory", Val: options.OutDir + "/" + img.Namespace + "-" + img.Deployment + "/"},
+			{Key: "Output Directory", Val: img.getPolicyDir()},
 			{Key: "policy-template version", Val: CurrentVersion},
 		},
 	}

--- a/recommend/report_text.go
+++ b/recommend/report_text.go
@@ -40,7 +40,7 @@ func (r TextReport) writeImageSummary(img *ImageInfo) {
 	t.Append([]string{"OS", img.OS})
 	t.Append([]string{"Arch", img.Arch})
 	t.Append([]string{"Distro", img.Distro})
-	t.Append([]string{"Output Directory", fmt.Sprintf("%s/%s-%s/", options.OutDir, img.Namespace, img.Deployment)})
+	t.Append([]string{"Output Directory", img.getPolicyDir()})
 	t.Append([]string{"policy-template version", CurrentVersion})
 	t.Render()
 }


### PR DESCRIPTION
- New flag `--config` to input the docker config to pull private repos (GCR,ECR,JFrog,Nexus,Docker private)
- Minor changes in reporting (solved output directory not showing for image recommendation)

Signed-off-by: Vishnu Soman <vishnu@accuknox.com>

**Example:**

**`karmor recommend` without config input**

```
➜  ~ karmor recommend -n accuknox-agents                              
INFO[0000] pulling image                                 image="agents.accuknox.com/repository/stable/shared-informer-agent:1.0"
FATA[0003] could not pull images using                   error="Error response from daemon: Head \"https://agents.accuknox.com/v2/repository/stable/shared-informer-agent/manifests/1.0\": no basic auth credentials"
➜  ~ karmor recommend -i knoxuser/testrepo:v1                         
INFO[0000] pulling image                                 image="knoxuser/testrepo:v1"
FATA[0003] could not pull images using                   error="Error response from daemon: pull access denied for knoxuser/testrepo, repository does not exist or may require 'docker login': denied: requested access to the resource is denied"
```

**`karmor recommend` with config input**

```
➜  ~ karmor recommend -n accuknox-agents -c ~/.docker/config.json
INFO[0000] pulling image                                 image="agents.accuknox.com/repository/stable/shared-informer-agent:1.0"
1.0: Pulling from repository/stable/shared-informer-agent
Digest: sha256:a9f7a522f2d0ae98e66c26760126babdeab35a192ed5afc8fd024949660a1b1c
Status: Image is up to date for agents.accuknox.com/repository/stable/shared-informer-agent:1.0
INFO[0007] dumped image to tar                           tar=/tmp/karmor1406145530/jvSWhBGL.tar

<<-------------------------------------------------->>SNIP<<-------------------------------------------------->>

➜  ~ karmor recommend -i knoxuser/testrepo:v1 -c ~/.docker/config.json
INFO[0000] pulling image                                 image="knoxuser/testrepo:v1"
v1: Pulling from knoxuser/testrepo
Digest: sha256:4981aea3282d17f6f684dfab15404452177f8c3bee1a02347530d83dd50b5d54
Status: Image is up to date for knoxuser/testrepo:v1
INFO[0014] dumped image to tar                           tar=/tmp/karmor3224732504/VxOpyYxN.tar
```
