### PR TITLE
[Enhancement] karmor recommend generic policies

### DIFF
--- a/recommend/policy.go
+++ b/recommend/policy.go
@@ -82,6 +82,9 @@ func (img *ImageInfo) checkPreconditions(ms MatchSpec) bool {
 	var matches []string
 	for _, preCondition := range ms.Precondition {
 		matches = append(matches, checkForSpec(filepath.Join(preCondition), img.FileList)...)
+		if strings.Contains(preCondition, "OPTSCAN") {
+			return true
+		}
 	}
 	return len(matches) >= len(ms.Precondition)
 }

--- a/recommend/report_html.go
+++ b/recommend/report_html.go
@@ -150,7 +150,7 @@ func (r HTMLReport) Record(ms MatchSpec, policyName string) error {
 			{Name: ms.Description.Tldr},
 			{Name: fmt.Sprintf("%d", ms.Spec.Severity)},
 			{Name: string(ms.Spec.Action)},
-			{Name: strings.Join(ms.Spec.Tags[:], ",")},
+			{Name: strings.Join(ms.Spec.Tags[:], "\n")},
 		},
 		Policy:      string(policy),
 		Description: ms.Description.Detailed,

--- a/recommend/report_text.go
+++ b/recommend/report_text.go
@@ -70,7 +70,7 @@ func (r TextReport) Record(ms MatchSpec, policyName string) error {
 	rec = append(rec, ms.Description.Tldr)
 	rec = append(rec, fmt.Sprintf("%d", ms.Spec.Severity))
 	rec = append(rec, string(ms.Spec.Action))
-	rec = append(rec, strings.Join(ms.Spec.Tags[:], ","))
+	rec = append(rec, strings.Join(ms.Spec.Tags[:], "\n"))
 	r.table.Append(rec)
 	return nil
 }


### PR DESCRIPTION
- Updated code to recommend generic linux policies even if docker pull fails

Signed-off-by: Vishnu Soman <vishnu@accuknox.com>

```sh
karmor recommend -n accuknox-agents -r agents.html
INFO[0000] pulling image                                 image="agents.accuknox.com/repository/stable/shared-informer-agent:1.0"
WARN[0001] Failed to pull image. Dumping generic policies. 
INFO[0001] No runtime policy generated for accuknox-agents/shared-informer-agent/agents.accuknox.com/repository/stable/shared-informer-agent:1.0 
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-maintenance-tool-access.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-cert-access.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-system-owner-discovery.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-system-monitoring-deny-write-under-bin-directory.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-system-monitoring-write-under-dev-directory.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-system-monitoring-detect-access-to-cronjob-files.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-least-functionality-execute-package-management-process-in-container.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-deny-remote-file-copy.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-deny-write-in-shm-folder.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-deny-write-under-etc-directory.yaml ...
created policy out/accuknox-agents-shared-informer-agent/agents-accuknox-com-repository-stable-shared-informer-agent-1-0-deny-write-under-etc-directory.yaml ...
output report in out/agents.html ...

```