### PR TITLE
matchLabels changes for discovery-engine

### DIFF
--- a/discover/discover.go
+++ b/discover/discover.go
@@ -35,7 +35,7 @@ type Options struct {
 	Fromsource  string
 }
 
-var matchLabels = map[string]string{"container": "knoxautopolicy"}
+var matchLabels = map[string]string{"app": "discovery-engine"}
 var port int64 = 9089
 
 // ConvertPolicy converts the knoxautopolicies to KubeArmor and Cilium policies

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -20,7 +20,7 @@ import (
 
 // DefaultReqType : default option for request type
 var DefaultReqType = "process,file,network"
-var matchLabels = map[string]string{"container": "knoxautopolicy"}
+var matchLabels = map[string]string{"app": "discovery-engine"}
 var port int64 = 9089
 
 // Options Structure


### PR DESCRIPTION
This PR contains changes for discovery-engine deployment's matchLabels
container: knoxautopolicy -> app: discovery-engine this has been changed. 

Note: Also in discovery-engine's deployment will change according to this naming changes.



Signed-off-by: yasin-cs-ko-ak <yasin@accuknox.com>

