### PR TITLE
bind port connections table for summarised data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 )
 
 require (
-	github.com/accuknox/auto-policy-discovery/src v0.0.0-20221129114555-66fc8ef6cfe4
+	github.com/accuknox/auto-policy-discovery/src v0.0.0-20221206061659-45c77dd83169
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDOSA=
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
-github.com/accuknox/auto-policy-discovery/src v0.0.0-20221129114555-66fc8ef6cfe4 h1:YMokhKwAQ0YU518HBeo5kDfoA+lTQ6F0efBKXG0at4U=
-github.com/accuknox/auto-policy-discovery/src v0.0.0-20221129114555-66fc8ef6cfe4/go.mod h1:op1lUWTnZLiYtot7e3GqQa+aZstvMg/ZvRMU0QBoNV4=
+github.com/accuknox/auto-policy-discovery/src v0.0.0-20221206061659-45c77dd83169 h1:3oijVWWFoIaFrbfRssaAU0lg5DPifxRsEQ7N3PHV3o4=
+github.com/accuknox/auto-policy-discovery/src v0.0.0-20221206061659-45c77dd83169/go.mod h1:op1lUWTnZLiYtot7e3GqQa+aZstvMg/ZvRMU0QBoNV4=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/summary/table.go
+++ b/summary/table.go
@@ -20,6 +20,8 @@ var (
 	SysFileHeader = []string{"Src Process", "Destination File Path", "Count", "Last Updated Time", "Status"}
 	// SysNwHeader variable contains protocol, command, POD/SVC/IP, Port, Namespace, and Labels
 	SysNwHeader = []string{"Protocol", "Command", "POD/SVC/IP", "Port", "Namespace", "Labels", "Count", "Last Updated Time"}
+	// SysBindNwHeader variable contains protocol, command, Bind Port, Bind Address, count and timestamp
+	SysBindNwHeader = []string{"Protocol", "Command", "Bind Port", "Bind Address", "Count", "Last Updated Time"}
 )
 
 // DisplaySummaryOutput function
@@ -139,6 +141,24 @@ func DisplaySummaryOutput(resp *opb.Response, revDNSLookup bool, requestType str
 				outNwRowData = append(outNwRowData, outNwStrSlice)
 			}
 			WriteTable(SysNwHeader, outNwRowData)
+			fmt.Printf("\n")
+		}
+
+		if len(resp.BindConnection) > 0 {
+			fmt.Printf("\nBind Points\n")
+			// Display bind connections details
+			bindNwRowData := [][]string{}
+			for _, bindConnection := range resp.BindConnection {
+				bindNwStrSlice := []string{}
+				bindNwStrSlice = append(bindNwStrSlice, bindConnection.Protocol)
+				bindNwStrSlice = append(bindNwStrSlice, bindConnection.Command)
+				bindNwStrSlice = append(bindNwStrSlice, bindConnection.BindPort)
+				bindNwStrSlice = append(bindNwStrSlice, bindConnection.BindAddress)
+				bindNwStrSlice = append(bindNwStrSlice, bindConnection.Count)
+				bindNwStrSlice = append(bindNwStrSlice, bindConnection.UpdatedTime)
+				bindNwRowData = append(bindNwRowData, bindNwStrSlice)
+			}
+			WriteTable(SysBindNwHeader, bindNwRowData)
 			fmt.Printf("\n")
 		}
 	}


### PR DESCRIPTION
This PR Contains 
- Bind Port Network Connection details for summarised data. 
- This will show when kubearmor log data has "SYS_BIND" under it's network data.
This is how sample output will look like.
```

Bind Port Connections
+----------+---------------------------+-----------------------------+-----------+--------------+-----------+--------+-------+------------------------------+
| PROTOCOL |          COMMAND          |         POD/SVC/IP          | BIND PORT | BIND ADDRESS | NAMESPACE | LABELS | COUNT |      LAST UPDATED TIME       |
+----------+---------------------------+-----------------------------+-----------+--------------+-----------+--------+-------+------------------------------+
| UNIX     | /usr/sbin/mysqld          | /var/run/mysqld/mysqld.sock |           |              |           |        | 2     | Tue Dec  6 08:16:13 UTC 2022 |
|          | /usr/lib/apt/methods/http |                             |           |              |           |        | 3     | Tue Dec  6 08:18:29 UTC 2022 |
|          | /bin/nc.traditional       |                             |           |              |           |        | 2     | Tue Dec  6 08:54:54 UTC 2022 |
+----------+---------------------------+-----------------------------+-----------+--------------+-----------+--------+-------+------------------------------+
```
if SYS_BIND doesn't happen it will show empty. 