### PR TITLE
add verbose flag for karmor probe

### DIFF
--- a/cmd/probe.go
+++ b/cmd/probe.go
@@ -25,16 +25,9 @@ If KubeArmor is running, It probes which environment KubeArmor is running on (e.
 the supported KubeArmor features in the environment, the pods being handled by KubeArmor and the policies running on each of these pods`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !verbose {
-			err := probe.PrintAnnotatedPods(client, probeInstallOptions)
-			if err != nil {
-				return err
-			}
-		} else {
-			if err := probe.PrintProbeResult(client, probeInstallOptions); err != nil {
-				return err
-			}
+			return probe.PrintAnnotatedPods(client, probeInstallOptions)
 		}
-		return nil
+		return probe.PrintProbeResult(client, probeInstallOptions); err != nil {
 	},
 }
 

--- a/cmd/probe.go
+++ b/cmd/probe.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var verbose bool
+
 var probeInstallOptions probe.Options
 
 // probeCmd represents the get command
@@ -22,16 +24,23 @@ and what KubeArmor features will be supported e.g: observability, enforcement, e
 If KubeArmor is running, It probes which environment KubeArmor is running on (e.g: systemd mode, kubernetes etc.), 
 the supported KubeArmor features in the environment, the pods being handled by KubeArmor and the policies running on each of these pods`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := probe.PrintProbeResult(client, probeInstallOptions); err != nil {
-			return err
+		if !verbose {
+			err := probe.PrintAnnotatedPods(client, probeInstallOptions)
+			if err != nil {
+				return err
+			}
+		} else {
+			if err := probe.PrintProbeResult(client, probeInstallOptions); err != nil {
+				return err
+			}
 		}
 		return nil
-
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(probeCmd)
+	probeCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "print verbose output of karmor probe")
 	probeCmd.Flags().StringVarP(&probeInstallOptions.Namespace, "namespace", "n", "kube-system", "Namespace for resources")
 	probeCmd.Flags().BoolVar(&probeInstallOptions.Full, "full", false, `If KubeArmor is not running, it deploys a daemonset to have access to more
 information on KubeArmor support in the environment and deletes daemonset after probing`)

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -70,7 +70,7 @@ func probeDaemonUninstaller(c *k8s.Client, o Options) error {
 	return nil
 }
 
-// only annotated pods and corresponding policies
+// PrintAnnotatedPods only annotated pods and corresponding policies
 func PrintAnnotatedPods(c *k8s.Client, o Options) error {
 	if isKubeArmorRunning(c, o) {
 		err := getAnnotatedPods(c)

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -70,6 +70,17 @@ func probeDaemonUninstaller(c *k8s.Client, o Options) error {
 	return nil
 }
 
+// only annotated pods and corresponding policies
+func PrintAnnotatedPods(c *k8s.Client, o Options) error {
+	if isKubeArmorRunning(c, o) {
+		err := getAnnotatedPods(c)
+		if err != nil {
+			log.Println("error occured when getting annotated pods", err)
+		}
+	}
+	return nil
+}
+
 // PrintProbeResult prints the result for the  host and k8s probing kArmor does to check compatibility with KubeArmor
 func PrintProbeResult(c *k8s.Client, o Options) error {
 	if runtime.GOOS != "linux" {


### PR DESCRIPTION
Signed-off-by: Anurag <contact.anurag7@gmail.com>

Fixes #226 

- Refactored the output of `karmor probe`.
- The usual loading time is 1/3rd of the existing one. 
- I tested this on a 3 node GKE cluster and results are following. 
```bash
# truncated
$ time ./kubearmor-client probe 
./kubearmor-client probe  0.09s user 0.01s system 1% cpu 6.258 total
$ time ./kubearmor-client probe -v 
./kubearmor-client probe -v  0.16s user 0.05s system 1% cpu 18.309 total
```
- The new output looks something like this. 
```bash
$ ./kubearmor-client probe

Found KubeArmor running in Kubernetes

Daemonset :
 	kubearmor 	Desired: 3	Ready: 3	Available: 3	
Armored Up pods :
+-----------+------+--------+
| NAMESPACE | NAME | POLICY |
+-----------+------+--------+
| default   | pod  |        |
+-----------+------+--------+
```