### PR TITLE
using default format as yaml

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -26,7 +26,7 @@ var discoverCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(discoverCmd)
 	discoverCmd.Flags().StringVar(&discoverOptions.GRPC, "gRPC", "", "gRPC server information")
-	discoverCmd.Flags().StringVarP(&discoverOptions.Format, "format", "f", "json", "Format: json or yaml")
+	discoverCmd.Flags().StringVarP(&discoverOptions.Format, "format", "f", "yaml", "Format: json or yaml")
 	discoverCmd.Flags().StringVarP(&discoverOptions.Policy, "policy", "p", "KubearmorSecurityPolicy", "Type of policies to be discovered: KubearmorSecurityPolicy|CiliumNetworkPolicy|NetworkPolicy")
 	discoverCmd.Flags().StringVarP(&discoverOptions.Namespace, "namespace", "n", "", "Filter by Namespace")
 	discoverCmd.Flags().StringVarP(&discoverOptions.Clustername, "clustername", "c", "", "Filter by Clustername")


### PR DESCRIPTION
Currently, when users use `karmor discover`, the policies are output in json format, while in most cases the users expect it to be in yaml format.

This PR changes the default format to yaml.

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>