### PR TITLE
Fixed karmor probe to show correct policies applied based on MatchLabels 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/charmbracelet/bubbles v0.14.0
 	github.com/charmbracelet/bubbletea v0.22.1
 	github.com/charmbracelet/lipgloss v0.6.0
+	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/evertras/bubble-table v0.14.6
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/d2g/hardwareaddr v0.0.0-20190221164911-e7d9fbe030e4/go.mod h1:bMl4RjI
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
+github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -605,7 +605,6 @@ func getAnnotatedPods(c *k8s.Client) error {
 			s1 := sliceToSet(labels)
 			for policyKey, policyValue := range policyMap {
 				s2 := sliceToSet(policyValue)
-				// log.Print(policyValue)
 				if s2.IsSubset(s1) {
 					if checkIfDataAlreadyContainsPodName(data, armoredPod.Name, policyKey) {
 						continue

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -599,10 +599,10 @@ func getAnnotatedPods(c *k8s.Client) error {
 			if err != nil {
 				return err
 			}
-			var k []string
+			var labels []string
 			data = append(data, []string{armoredPod.Namespace, armoredPod.Name, ""})
-			k =  getAnnotatedPodLabels(armoredPod.Labels, k)
-				s1 := sliceToSet(k)
+			labels =  getAnnotatedPodLabels(armoredPod.Labels, labels)
+				s1 := sliceToSet(labels)
 				for policyKey, policyValue := range policyMap {
 					s2 := sliceToSet(policyValue)
 					// log.Print(policyValue)

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -572,12 +572,13 @@ func probeSystemdMode() error {
 	return nil
 }
 
-func getAnnotatedPodLabels(m map[string]string, a []string) []string {
+func getAnnotatedPodLabels(m map[string]string) mapset.Set[string] {
+	var a []string
 	for key, value := range m {
 		a = append(a, key+":"+value)
 	}
-
-	return a
+	b := sliceToSet(a)
+	return b
 }
 
 func getAnnotatedPods(c *k8s.Client) error {
@@ -599,13 +600,11 @@ func getAnnotatedPods(c *k8s.Client) error {
 			if err != nil {
 				return err
 			}
-			var labels []string
 			data = append(data, []string{armoredPod.Namespace, armoredPod.Name, ""})
-			labels = getAnnotatedPodLabels(armoredPod.Labels, labels)
-			s1 := sliceToSet(labels)
+			labels := getAnnotatedPodLabels(armoredPod.Labels)
 			for policyKey, policyValue := range policyMap {
 				s2 := sliceToSet(policyValue)
-				if s2.IsSubset(s1) {
+				if s2.IsSubset(labels) {
 					if checkIfDataAlreadyContainsPodName(data, armoredPod.Name, policyKey) {
 						continue
 					} else {

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -574,7 +574,7 @@ func probeSystemdMode() error {
 
 func getAnnotatedPodLabels(m map[string]string, a []string) []string {
 	for key, value := range m {
-		a =append(a, key+":"+value)
+		a = append(a, key+":"+value)
 	}
 
 	return a
@@ -601,20 +601,20 @@ func getAnnotatedPods(c *k8s.Client) error {
 			}
 			var labels []string
 			data = append(data, []string{armoredPod.Namespace, armoredPod.Name, ""})
-			labels =  getAnnotatedPodLabels(armoredPod.Labels, labels)
-				s1 := sliceToSet(labels)
-				for policyKey, policyValue := range policyMap {
-					s2 := sliceToSet(policyValue)
-					// log.Print(policyValue)
-					if s2.IsSubset(s1) {
-						if checkIfDataAlreadyContainsPodName(data, armoredPod.Name, policyKey) {
-							continue
-						} else {		
-							data = append(data, []string{armoredPod.Namespace, armoredPod.Name, policyKey})
-						}
+			labels = getAnnotatedPodLabels(armoredPod.Labels, labels)
+			s1 := sliceToSet(labels)
+			for policyKey, policyValue := range policyMap {
+				s2 := sliceToSet(policyValue)
+				// log.Print(policyValue)
+				if s2.IsSubset(s1) {
+					if checkIfDataAlreadyContainsPodName(data, armoredPod.Name, policyKey) {
+						continue
+					} else {
+						data = append(data, []string{armoredPod.Namespace, armoredPod.Name, policyKey})
 					}
 				}
 			}
+		}
 	}
 	_, err = boldWhite.Printf("Armored Up pods : \n")
 	if err != nil {


### PR DESCRIPTION
Fixes #205 

## The Problem before

The issue with karmor probe was how labels were handled, where if even one `MatchLabel` from the policy matched with the current Pod Label, it would hold true, i.e using Logical OR instead of logical AND.

## The Solution

I used the package https://github.com/deckarep/golang-set, and the logic is that there are two sets (like python sets): Pod Labels and the MatchLabel mentioned in the ksp policy, and now `karmor probe` will show that the policy is only applied when all labels mentioned in `MatchLabels`  is there in the actual Pod Label. 
I found this easier than to manually implement to compare two different slices.

The time complexity of above approach is linear time. The time complexity of issubset itself is O(n), where n is length of a set we are checking if subset, in this case s2. There is also conversion from slice to set that is also linear time.

![image](https://user-images.githubusercontent.com/23097199/210664155-e9e19ece-fffe-465f-96c2-d9c8a54e4b59.png)
