### PR TITLE
consistent use of short/long options

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -12,7 +12,7 @@ var logOptions log.Options
 
 // logCmd represents the log command
 var logCmd = &cobra.Command{
-	Use:   "log",
+	Use:   "logs",
 	Short: "Observe Logs from KubeArmor",
 	Long:  `Observe Logs from KubeArmor`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -32,7 +32,7 @@ func init() {
 	logCmd.Flags().StringVar(&logOptions.LogPath, "logPath", "stdout", "Output location for alerts and logs, {path|stdout|none}")
 	logCmd.Flags().StringVar(&logOptions.LogFilter, "logFilter", "policy", "Filter for what kinds of alerts and logs to receive, {policy|system|all}")
 	logCmd.Flags().BoolVar(&logOptions.JSON, "json", false, "Flag to print alerts and logs in the JSON format")
-	logCmd.Flags().StringVar(&logOptions.Namespace, "namespace", "", "Specify the namespace")
+	logCmd.Flags().StringVarP(&logOptions.Namespace, "namespace", "n", "", "k8s namespace filter")
 	logCmd.Flags().StringVar(&logOptions.Operation, "operation", "", "Give the type of the operation (Eg:Process/File/Network)")
 	logCmd.Flags().StringVar(&logOptions.LogType, "logType", "", "Log type you want (Eg:ContainerLog/HostLog) ")
 	logCmd.Flags().StringVar(&logOptions.ContainerName, "container", "", "name of the container ")
@@ -40,5 +40,5 @@ func init() {
 	logCmd.Flags().StringVar(&logOptions.Resource, "resource", "", "command used by the user")
 	logCmd.Flags().StringVar(&logOptions.Source, "source", "", "binary used by the system ")
 	logCmd.Flags().Uint32Var(&logOptions.Limit, "limit", 0, "number of logs you want to see")
-	logCmd.Flags().StringArrayVarP(&logOptions.Selector, "selector", "l", []string{}, "use the label to get the particular log")
+	logCmd.Flags().StringSliceVarP(&logOptions.Selector, "labels", "l", []string{}, "use the labels to select the endpoints")
 }


### PR DESCRIPTION
* changed `karmor log` to `karmor logs` ... since `kubectl logs`
* using short option of "-n" for namespace in `karmor logs`

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>