### PR TITLE
updated error message for failing to find pods before port forward

### DIFF
--- a/discover/discover.go
+++ b/discover/discover.go
@@ -42,6 +42,7 @@ var port int64 = 9089
 // ConvertPolicy converts the knoxautopolicies to KubeArmor and Cilium policies
 func ConvertPolicy(c *k8s.Client, o Options) error {
 	gRPC := ""
+	targetPodName := "discovery-engine"
 
 	if o.GRPC != "" {
 		gRPC = o.GRPC
@@ -49,7 +50,7 @@ func ConvertPolicy(c *k8s.Client, o Options) error {
 		if val, ok := os.LookupEnv("DISCOVERY_SERVICE"); ok {
 			gRPC = val
 		} else {
-			pf, err := utils.InitiatePortForward(c, port, port, matchLabels)
+			pf, err := utils.InitiatePortForward(c, port, port, matchLabels, targetPodName)
 			if err != nil {
 				return err
 			}

--- a/discover/discover.go
+++ b/discover/discover.go
@@ -42,7 +42,7 @@ var port int64 = 9089
 // ConvertPolicy converts the knoxautopolicies to KubeArmor and Cilium policies
 func ConvertPolicy(c *k8s.Client, o Options) error {
 	gRPC := ""
-	targetPodName := "discovery-engine"
+	targetSvc := "discovery-engine"
 
 	if o.GRPC != "" {
 		gRPC = o.GRPC
@@ -50,7 +50,7 @@ func ConvertPolicy(c *k8s.Client, o Options) error {
 		if val, ok := os.LookupEnv("DISCOVERY_SERVICE"); ok {
 			gRPC = val
 		} else {
-			pf, err := utils.InitiatePortForward(c, port, port, matchLabels, targetPodName)
+			pf, err := utils.InitiatePortForward(c, port, port, matchLabels, targetSvc)
 			if err != nil {
 				return err
 			}

--- a/log/log.go
+++ b/log/log.go
@@ -117,13 +117,14 @@ func closeStopChan() {
 // StartObserver Function
 func StartObserver(c *k8s.Client, o Options) error {
 	gRPC := ""
+	targetPodName := "kubearmor-relay"
 
 	if o.GRPC != "" {
 		gRPC = o.GRPC
 	} else if val, ok := os.LookupEnv("KUBEARMOR_SERVICE"); ok {
 		gRPC = val
 	} else {
-		pf, err := utils.InitiatePortForward(c, port, port, matchLabels)
+		pf, err := utils.InitiatePortForward(c, port, port, matchLabels, targetPodName)
 		if err != nil {
 			return err
 		}

--- a/log/log.go
+++ b/log/log.go
@@ -117,14 +117,14 @@ func closeStopChan() {
 // StartObserver Function
 func StartObserver(c *k8s.Client, o Options) error {
 	gRPC := ""
-	targetPodName := "kubearmor-relay"
+	targetSvc := "kubearmor-relay"
 
 	if o.GRPC != "" {
 		gRPC = o.GRPC
 	} else if val, ok := os.LookupEnv("KUBEARMOR_SERVICE"); ok {
 		gRPC = val
 	} else {
-		pf, err := utils.InitiatePortForward(c, port, port, matchLabels, targetPodName)
+		pf, err := utils.InitiatePortForward(c, port, port, matchLabels, targetSvc)
 		if err != nil {
 			return err
 		}

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -42,7 +42,7 @@ type Options struct {
 // Summary : Get summary on pods
 func Summary(c *k8s.Client, o Options) error {
 	gRPC := ""
-	targetPodName := "discovery-engine"
+	targetSvc := "discovery-engine"
 
 	if o.GRPC != "" {
 		gRPC = o.GRPC
@@ -50,7 +50,7 @@ func Summary(c *k8s.Client, o Options) error {
 		if val, ok := os.LookupEnv("DISCOVERY_SERVICE"); ok {
 			gRPC = val
 		} else {
-			pf, err := utils.InitiatePortForward(c, port, port, matchLabels, targetPodName)
+			pf, err := utils.InitiatePortForward(c, port, port, matchLabels, targetSvc)
 			if err != nil {
 				return err
 			}

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -42,6 +42,7 @@ type Options struct {
 // Summary : Get summary on pods
 func Summary(c *k8s.Client, o Options) error {
 	gRPC := ""
+	targetPodName := "discovery-engine"
 
 	if o.GRPC != "" {
 		gRPC = o.GRPC
@@ -49,7 +50,7 @@ func Summary(c *k8s.Client, o Options) error {
 		if val, ok := os.LookupEnv("DISCOVERY_SERVICE"); ok {
 			gRPC = val
 		} else {
-			pf, err := utils.InitiatePortForward(c, port, port, matchLabels)
+			pf, err := utils.InitiatePortForward(c, port, port, matchLabels, targetPodName)
 			if err != nil {
 				return err
 			}

--- a/utils/portforward.go
+++ b/utils/portforward.go
@@ -22,22 +22,22 @@ import (
 
 // PortForwardOpt details for a pod
 type PortForwardOpt struct {
-	LocalPort     int64
-	RemotePort    int64
-	MatchLabels   map[string]string
-	Namespace     string
-	PodName       string
-	TargetPodName string
+	LocalPort   int64
+	RemotePort  int64
+	MatchLabels map[string]string
+	Namespace   string
+	PodName     string
+	TargetSvc   string
 }
 
 // InitiatePortForward : Initiate port forwarding
-func InitiatePortForward(c *k8s.Client, localPort int64, remotePort int64, matchLabels map[string]string, targetPodName string) (PortForwardOpt, error) {
+func InitiatePortForward(c *k8s.Client, localPort int64, remotePort int64, matchLabels map[string]string, targetSvc string) (PortForwardOpt, error) {
 	pf := PortForwardOpt{
-		LocalPort:     localPort,
-		RemotePort:    remotePort,
-		Namespace:     "",
-		MatchLabels:   matchLabels,
-		TargetPodName: targetPodName,
+		LocalPort:   localPort,
+		RemotePort:  remotePort,
+		Namespace:   "",
+		MatchLabels: matchLabels,
+		TargetSvc:   targetSvc,
 	}
 
 	// handle port forward
@@ -120,7 +120,7 @@ func (pf *PortForwardOpt) getPodName(c *k8s.Client) error {
 		return err
 	}
 	if len(podList.Items) == 0 {
-		return fmt.Errorf("kubearmor %s pod not found", pf.TargetPodName)
+		return fmt.Errorf("%s svc not found", pf.TargetSvc)
 	}
 	pf.PodName = podList.Items[0].GetObjectMeta().GetName()
 	pf.Namespace = podList.Items[0].GetObjectMeta().GetNamespace()

--- a/utils/portforward.go
+++ b/utils/portforward.go
@@ -22,20 +22,22 @@ import (
 
 // PortForwardOpt details for a pod
 type PortForwardOpt struct {
-	LocalPort   int64
-	RemotePort  int64
-	MatchLabels map[string]string
-	Namespace   string
-	PodName     string
+	LocalPort     int64
+	RemotePort    int64
+	MatchLabels   map[string]string
+	Namespace     string
+	PodName       string
+	TargetPodName string
 }
 
 // InitiatePortForward : Initiate port forwarding
-func InitiatePortForward(c *k8s.Client, localPort int64, remotePort int64, matchLabels map[string]string) (PortForwardOpt, error) {
+func InitiatePortForward(c *k8s.Client, localPort int64, remotePort int64, matchLabels map[string]string, targetPodName string) (PortForwardOpt, error) {
 	pf := PortForwardOpt{
-		LocalPort:   localPort,
-		RemotePort:  remotePort,
-		Namespace:   "",
-		MatchLabels: matchLabels,
+		LocalPort:     localPort,
+		RemotePort:    remotePort,
+		Namespace:     "",
+		MatchLabels:   matchLabels,
+		TargetPodName: targetPodName,
 	}
 
 	// handle port forward
@@ -118,7 +120,7 @@ func (pf *PortForwardOpt) getPodName(c *k8s.Client) error {
 		return err
 	}
 	if len(podList.Items) == 0 {
-		return errors.New("kubearmor pod not found")
+		return fmt.Errorf("kubearmor %s pod not found", pf.TargetPodName)
 	}
 	pf.PodName = podList.Items[0].GetObjectMeta().GetName()
 	pf.Namespace = podList.Items[0].GetObjectMeta().GetNamespace()


### PR DESCRIPTION
Signed-off-by: sibashi <fangedhamster3114@gmail.com>
 
  * while doing port-forward , if pod is not found , the error message is always 
           `Error: kubearmor pod not found`
           
           
Now the new error message also specifies the pod that was supposed to be found
For example in case of `karmor summary` if the client fails to find to find the pod
  
`Error: kubearmor discovery-engine pod not found`


