### PR TITLE
updated localPort value to not bind with with any port to be used by …

### DIFF
--- a/utils/portforward.go
+++ b/utils/portforward.go
@@ -129,8 +129,6 @@ func (pf *PortForwardOpt) getPodName(c *k8s.Client) error {
 func (pf *PortForwardOpt) getLocalPort() (int64, error) {
 
 	for {
-		port := pf.LocalPort
-
 		port, err := getRandomPort()
 		if err != nil {
 			return port, err

--- a/utils/portforward.go
+++ b/utils/portforward.go
@@ -127,9 +127,14 @@ func (pf *PortForwardOpt) getPodName(c *k8s.Client) error {
 
 // Returns the local port for the port forwarder
 func (pf *PortForwardOpt) getLocalPort() (int64, error) {
-	port := pf.LocalPort
 
 	for {
+		port := pf.LocalPort
+
+		port, err := getRandomPort()
+		if err != nil {
+			return port, err
+		}
 		listener, err := net.Listen("tcp", "127.0.0.1:"+strconv.FormatInt(port, 10))
 		if err == nil {
 			if err := listener.Close(); err != nil {
@@ -138,20 +143,17 @@ func (pf *PortForwardOpt) getLocalPort() (int64, error) {
 			fmt.Fprintf(os.Stderr, "local port to be used for port forwarding %s: %d \n", pf.PodName, port)
 			return port, nil
 		}
-
-		n, err := getRandomInt()
-		if err != nil {
-			return n, err
-		}
-		port = n + 32768
 	}
+
 }
 
-// get random integer
-func getRandomInt() (int64, error) {
+// Return a port number > 32767
+func getRandomPort() (int64, error) {
 	n, err := rand.Int(rand.Reader, big.NewInt(32900-32768))
 	if err != nil {
 		return -1, errors.New("unable to generate random integer for port")
 	}
-	return n.Int64(), nil
+
+	var portNo = n.Int64() + 32768
+	return portNo, nil
 }


### PR DESCRIPTION
Signed-off-by: sibashi <fangedhamster3114@gmail.com>

Fixes [KubeArmor-#1051](https://github.com/kubearmor/KubeArmor/issues/1051)  

 * previously karmor used to bind to port 32767 , if `karmor log` was used before all KubeArmor were running during `karmor install` . This caused `kubearmor` pod failing to run , as it requires to use 32767

     
 * Now karmor would not bind to 32767 , instead keep looking for other local ports  > 32767