### PR TITLE
Added check for update in any mandatory release of karmor CLI

### DIFF
--- a/checks/updates.go
+++ b/checks/updates.go
@@ -1,0 +1,53 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/google/go-github/github"
+	"github.com/kubearmor/kubearmor-client/selfupdate"
+	"strings"
+)
+
+func CheckForUpdates() error {
+	client := github.NewClient(nil)
+
+	// Fetch all releases from the GitHub API
+	releases, _, err := client.Repositories.ListReleases(context.Background(),
+		"kubearmor",
+		"kubearmor-client",
+		&github.ListOptions{
+			Page:    1,
+			PerPage: 100,
+		},
+	)
+	if err != nil {
+		fmt.Println("Error fetching releases:", err)
+		return err
+	}
+
+	// Find the latest release with the keyword "mandatory" in its release notes
+	var latestMandatoryRelease *github.RepositoryRelease
+	for _, release := range releases {
+		if strings.Contains(*release.Body, "mandatory") {
+			latestMandatoryRelease = release
+			break
+		}
+	}
+
+	// Compare the current version with the latest release version
+	currentVersion := selfupdate.GitSummary
+	if err != nil {
+		return err
+	}
+	if latestMandatoryRelease != nil && !strings.EqualFold(currentVersion, *latestMandatoryRelease.TagName) {
+		color.HiMagenta("A mandatory update is available (current version: %s, latest release: %s).\n",
+			currentVersion,
+			*latestMandatoryRelease.TagName,
+		)
+	} else {
+		fmt.Println("The client is up to date.")
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -4,8 +4,12 @@
 // Package main is responsible for the execution of CLI
 package main
 
-import "github.com/kubearmor/kubearmor-client/cmd"
+import (
+	"github.com/kubearmor/kubearmor-client/checks"
+	"github.com/kubearmor/kubearmor-client/cmd"
+)
 
 func main() {
 	cmd.Execute()
+	checks.CheckForUpdates()
 }

--- a/version/version.go
+++ b/version/version.go
@@ -23,7 +23,7 @@ func PrintVersion(c *k8s.Client) error {
 		color.HiMagenta("update available version " + latestVer)
 		color.HiMagenta("use [karmor selfupdate] to update to latest")
 	}
-	kubearmorVersion, err := getKubeArmorVersion(c)
+	kubearmorVersion, err := GetKubeArmorVersion(c)
 	if err != nil {
 		return nil
 	}
@@ -35,7 +35,7 @@ func PrintVersion(c *k8s.Client) error {
 	return nil
 }
 
-func getKubeArmorVersion(c *k8s.Client) (string, error) {
+func GetKubeArmorVersion(c *k8s.Client) (string, error) {
 	pods, err := c.K8sClientset.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{LabelSelector: "kubearmor-app=kubearmor"})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Signed-off-by: sibashi <fangedhamster3114@gmail.com>

Fixes #249 

 the function checkForUpdates first finds the latest release that contains the keyword "mandatory" in its release notes 
 compared it with current version from `selfupdate.GitSummary`
 If diffrent informs the user