### PR TITLE
Added host-visibility to probe sub-command

### DIFF
--- a/probe/probe.go
+++ b/probe/probe.go
@@ -534,11 +534,7 @@ func printKubeArmorProbeOutput(buf []byte) error {
 	data = append(data, []string{" ", "Container Security:", green(strconv.FormatBool(kd.ContainerSecurity))})
 	data = append(data, []string{" ", "Container Default Posture:", green(kd.ContainerDefaultPosture.FileAction) + itwhite("(File)"), green(kd.ContainerDefaultPosture.FileAction) + itwhite("(Capabilities)"), green(kd.ContainerDefaultPosture.NetworkAction) + itwhite("(Network)")})
 	data = append(data, []string{" ", "Host Default Posture:", green(kd.HostDefaultPosture.FileAction) + itwhite("(File)"), green(kd.HostDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.HostDefaultPosture.NetworkAction) + itwhite("(Network)")})
-	hv := strings.Split(kd.HostVisibility, ",")
-	for i := len(hv) - 1; i < 4; i++ { // Possible values : none/process,file,network,capabilities
-		hv = append(hv, "")
-	}
-	data = append(data, []string{" ", "Host Visibility:", green(hv[0]), green(hv[1]), green(hv[2]), green(hv[3])})
+	data = append(data, []string{" ", "Host Visibility:", green(kd.HostVisibility)})
 	renderOutputInTableWithNoBorders(data)
 	return nil
 }

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -356,6 +356,7 @@ type KubeArmorProbeData struct {
 	ContainerSecurity       bool
 	ContainerDefaultPosture tp.DefaultPosture
 	HostDefaultPosture      tp.DefaultPosture
+	HostVisibility          string
 }
 
 func isKubeArmorRunning(c *k8s.Client, o Options) bool {
@@ -533,6 +534,11 @@ func printKubeArmorProbeOutput(buf []byte) error {
 	data = append(data, []string{" ", "Container Security:", green(strconv.FormatBool(kd.ContainerSecurity))})
 	data = append(data, []string{" ", "Container Default Posture:", green(kd.ContainerDefaultPosture.FileAction) + itwhite("(File)"), green(kd.ContainerDefaultPosture.FileAction) + itwhite("(Capabilities)"), green(kd.ContainerDefaultPosture.NetworkAction) + itwhite("(Network)")})
 	data = append(data, []string{" ", "Host Default Posture:", green(kd.HostDefaultPosture.FileAction) + itwhite("(File)"), green(kd.HostDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.HostDefaultPosture.NetworkAction) + itwhite("(Network)")})
+	hv := strings.Split(kd.HostVisibility, ",")
+	for i := len(hv) - 1; i < 4; i++ { // Possible values : none/process,file,network,capabilities
+		hv = append(hv, "")
+	}
+	data = append(data, []string{" ", "Host Visibility:", green(hv[0]), green(hv[1]), green(hv[2]), green(hv[3])})
 	renderOutputInTableWithNoBorders(data)
 	return nil
 }


### PR DESCRIPTION
This draft PR is for issue #199 
The host-visbility variable is treated as a string as in the karmor project. Below are the possible test cases :

**Test case 1**: Host visibility is _none_
```
bash-5.1# cat /tmp/karmorProbeData.cfg 
{"OSImage":"Ubuntu 22.04.1 LTS","KernelVersion":"5.15.0-58-generic","KubeletVersion":"v1.23.9+k3s1","ContainerRuntime":"docker://20.10.12","ActiveLSM":"AppArmor","KernelHeaderPresent":true,"HostSecurity":true,"ContainerSecurity":true,"ContainerDefaultPosture":{"file":"audit","network":"audit","capabilties":"audit"},"HostDefaultPosture":{"file":"audit","network":"audit","capabilties":"audit"},"HostVisibility":"none"}
```
![image](https://user-images.githubusercontent.com/1323423/216473637-5fbe59e4-092b-47af-a255-131410664469.png)

**Test case 2** : Host visibility is _process,file_

```
bash-5.1# cat /tmp/karmorProbeData.cfg 
{"OSImage":"Ubuntu 22.04.1 LTS","KernelVersion":"5.15.0-58-generic","KubeletVersion":"v1.23.9+k3s1","ContainerRuntime":"docker://20.10.12","ActiveLSM":"AppArmor","KernelHeaderPresent":true,"HostSecurity":true,"ContainerSecurity":true,"ContainerDefaultPosture":{"file":"audit","network":"audit","capabilties":"audit"},"HostDefaultPosture":{"file":"audit","network":"audit","capabilties":"audit"},"HostVisibility":"process,file"}

```
 
![image](https://user-images.githubusercontent.com/1323423/216473826-0b737999-873f-41e4-b4dc-f61d3146fefc.png)

**Test case 2** : Host visibility is _process,file, network,capabilities_

```
bash-5.1# cat /tmp/karmorProbeData.cfg 
{"OSImage":"Ubuntu 22.04.1 LTS","KernelVersion":"5.15.0-58-generic","KubeletVersion":"v1.23.9+k3s1","ContainerRuntime":"docker://20.10.12","ActiveLSM":"AppArmor","KernelHeaderPresent":true,"HostSecurity":true,"ContainerSecurity":true,"ContainerDefaultPosture":{"file":"audit","network":"audit","capabilties":"audit"},"HostDefaultPosture":{"file":"audit","network":"audit","capabilties":"audit"},"HostVisibility":"process,file,network,capabilities"}
```

![image](https://user-images.githubusercontent.com/1323423/216473894-3e652d68-738f-4370-97d9-a5a98af4efb1.png)

