### PR TITLE
Added block posture flag in install

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -30,6 +30,7 @@ func init() {
 	installCmd.Flags().StringVarP(&installOptions.Namespace, "namespace", "n", "kube-system", "Namespace for resources")
 	installCmd.Flags().StringVarP(&installOptions.KubearmorImage, "image", "i", "kubearmor/kubearmor:stable", "Kubearmor daemonset image to use")
 	installCmd.Flags().StringVarP(&installOptions.Audit, "audit", "a", "", "Kubearmor Audit Posture Context [all,file,network,capabilities]")
+	installCmd.Flags().StringVarP(&installOptions.Block, "block", "b", "", "Kubearmor Block Posture Context [all,file,network,capabilities]")
 	installCmd.Flags().BoolVar(&installOptions.Save, "save", false, "Save KubeArmor Manifest ")
 
 }

--- a/install/install.go
+++ b/install/install.go
@@ -244,13 +244,13 @@ func K8sInstaller(c *k8s.Client, o Options) error {
 	if o.Audit == "all" || strings.Contains(o.Audit, "capabilities") {
 		daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, "-defaultCapabilitiesPosture=audit")
 	}
-	if o.Block == "all" || strings.Contains(o.Audit, "file") {
+	if o.Block == "all" || strings.Contains(o.Block, "file") {
 		daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, "-defaultFilePosture=block")
 	}
-	if o.Block == "all" || strings.Contains(o.Audit, "network") {
+	if o.Block == "all" || strings.Contains(o.Block, "network") {
 		daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, "-defaultNetworkPosture=block")
 	}
-	if o.Block == "all" || strings.Contains(o.Audit, "capabilities") {
+	if o.Block == "all" || strings.Contains(o.Block, "capabilities") {
 		daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, "-defaultCapabilitiesPosture=block")
 	}
 	s := strings.Join(daemonset.Spec.Template.Spec.Containers[0].Args, " ")

--- a/install/install.go
+++ b/install/install.go
@@ -33,6 +33,7 @@ type Options struct {
 	Namespace      string
 	KubearmorImage string
 	Audit          string
+	Block          string
 	Force          bool
 	Save           bool
 	Animation      bool
@@ -242,6 +243,15 @@ func K8sInstaller(c *k8s.Client, o Options) error {
 	}
 	if o.Audit == "all" || strings.Contains(o.Audit, "capabilities") {
 		daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, "-defaultCapabilitiesPosture=audit")
+	}
+	if o.Block == "all" || strings.Contains(o.Audit, "file") {
+		daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, "-defaultFilePosture=block")
+	}
+	if o.Block == "all" || strings.Contains(o.Audit, "network") {
+		daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, "-defaultNetworkPosture=block")
+	}
+	if o.Block == "all" || strings.Contains(o.Audit, "capabilities") {
+		daemonset.Spec.Template.Spec.Containers[0].Args = append(daemonset.Spec.Template.Spec.Containers[0].Args, "-defaultCapabilitiesPosture=block")
 	}
 	s := strings.Join(daemonset.Spec.Template.Spec.Containers[0].Args, " ")
 	printMessage("🛡   KubeArmor DaemonSet"+daemonset.Spec.Template.Spec.Containers[0].Image+s+"  ", true)


### PR DESCRIPTION
Using `karmor install --block` flag we can apply the block posture across the node now.