### PR TITLE
Updated install command to receive env as argument

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/kubearmor/kubearmor-client/install"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,9 @@ var installCmd = &cobra.Command{
 	Long:  `Install KubeArmor in a Kubernetes Clusters`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		installOptions.Animation = true
+		if err := installOptions.Env.CheckAndSetValidEnvironmentOption(cmd.Flag("env").Value.String()); err != nil {
+			return fmt.Errorf("error in checking environment option: %v", err)
+		}
 		if err := install.K8sInstaller(client, installOptions); err != nil {
 			return err
 		}
@@ -31,5 +35,6 @@ func init() {
 	installCmd.Flags().StringVarP(&installOptions.KubearmorImage, "image", "i", "kubearmor/kubearmor:stable", "Kubearmor daemonset image to use")
 	installCmd.Flags().StringVarP(&installOptions.Audit, "audit", "a", "", "Kubearmor Audit Posture Context [all,file,network,capabilities]")
 	installCmd.Flags().BoolVar(&installOptions.Save, "save", false, "Save KubeArmor Manifest ")
+	installCmd.Flags().StringVarP(&installOptions.Env.Environment, "env", "e", "", "Supported KubeArmor Environment [k3s,microK8s,minikube,gke,bottlerocket,eks,docker,oke,generic]")
 
 }

--- a/install/install.go
+++ b/install/install.go
@@ -37,10 +37,10 @@ type Options struct {
 	Force          bool
 	Save           bool
 	Animation      bool
-	Env            EnvOption
+	Env            envOption
 }
 
-type EnvOption struct {
+type envOption struct {
 	Auto        bool
 	Environment string
 }
@@ -50,17 +50,18 @@ var progress int
 var cursorcount int
 var validEnvironments = []string{"k3s", "microK8s", "minikube", "gke", "bottlerocket", "eks", "docker", "oke", "generic"}
 
-func (env *EnvOption) CheckAndSetValidEnvironmentOption(envOption string) error {
+// Checks if passed string is a valid environment
+func (env *envOption) CheckAndSetValidEnvironmentOption(envOption string) error {
+	if envOption == "" {
+		env.Auto = true
+		return nil
+	}
 	for _, v := range validEnvironments {
 		if v == envOption {
 			env.Environment = envOption
 			env.Auto = false
 			return nil
 		}
-	}
-	env.Auto = true
-	if envOption == "" {
-		return nil
 	}
 	return errors.New("Invalid environment passed")
 }

--- a/utils/portforward.go
+++ b/utils/portforward.go
@@ -1,3 +1,4 @@
+// Package utils provides utility for port forwarding.
 package utils
 
 import (


### PR DESCRIPTION
Signed-off-by: sibashi <fangedhamster3114@gmail.com>

Fixes #252

- user can pass no env flag , in such case `AutoDetectEnvironment` will be called
- if valid environment is passed as flad eg  `karmor install -e k3s`  env variable would be manually set