### PR TITLE
Pass all CLI options to discovery-client

### DIFF
--- a/summary/summary.go
+++ b/summary/summary.go
@@ -66,6 +66,7 @@ func GetSummary(c *k8s.Client, o Options) ([]string, error) {
 		ClusterName:   o.ClusterName,
 		ContainerName: o.ContainerName,
 		Aggregate:     o.Aggregation,
+		Type:          o.Type,
 	}
 
 	// create a client
@@ -78,11 +79,7 @@ func GetSummary(c *k8s.Client, o Options) ([]string, error) {
 	client := opb.NewObservabilityClient(conn)
 
 	if data.PodName != "" {
-		sumResp, err := client.Summary(context.Background(), &opb.Request{
-			PodName:   data.PodName,
-			Type:      o.Type,
-			Aggregate: o.Aggregation,
-		})
+		sumResp, err := client.Summary(context.Background(), data)
 		if err != nil {
 			return nil, err
 		}
@@ -109,11 +106,8 @@ func GetSummary(c *k8s.Client, o Options) ([]string, error) {
 			if podname == "" {
 				continue
 			}
-			sumResp, err := client.Summary(context.Background(), &opb.Request{
-				PodName:   podname,
-				Type:      o.Type,
-				Aggregate: o.Aggregation,
-			})
+			data.PodName = podname
+			sumResp, err := client.Summary(context.Background(), data)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Main issue: https://github.com/accuknox/discovery-engine/issues/675
Discovery engine PR: https://github.com/accuknox/discovery-engine/pull/679

Proof of working:
```bash
$ karmor summary -p nginx --container nginx                             
local port to be used for port forwarding discovery-engine-68bfd8f58-ghqsg: 32779 

  Pod Name        nginx      
  Namespace Name  default    
  Cluster Name    default    
  Container Name  nginx      
  Labels          run=nginx  

Process Data
+-------------+--------------------------+-------+------------------------------+--------+
| SRC PROCESS | DESTINATION PROCESS PATH | COUNT |      LAST UPDATED TIME       | STATUS |
+-------------+--------------------------+-------+------------------------------+--------+
| /bin/bash   | /bin/ls                  | 1     | Mon Mar  6 18:01:28 UTC 2023 | Allow  |
| /bin/bash   | /usr/bin/clear           | 1     | Mon Mar  6 18:01:30 UTC 2023 | Allow  |
+-------------+--------------------------+-------+------------------------------+--------+


File Data
+----------------+------------------------------------------------+-------+------------------------------+--------+
|  SRC PROCESS   |             DESTINATION FILE PATH              | COUNT |      LAST UPDATED TIME       | STATUS |
+----------------+------------------------------------------------+-------+------------------------------+--------+
| /bin/bash      | /dev/tty                                       | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/bash      | /etc/bash.bashrc                               | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/bash      | /etc/inputrc                                   | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/bash      | /etc/ld.so.cache                               | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/bash      | /etc/passwd                                    | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/bash      | /lib/terminfo/x/xterm                          | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/bash      | /lib/x86_64-linux-gnu/libc-2.31.so             | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/bash      | /lib/x86_64-linux-gnu/libdl-2.31.so            | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/bash      | /lib/x86_64-linux-gnu/libnss_files-2.31.so     | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/bash      | /root/.bash_history                            | 2     | Mon Mar  6 18:01:33 UTC 2023 | Allow  |
| /bin/bash      | /root/.bashrc                                  | 1     | Mon Mar  6 18:01:27 UTC 2023 | Allow  |
| /bin/ls        | /etc/ld.so.cache                               | 1     | Mon Mar  6 18:01:28 UTC 2023 | Allow  |
| /bin/ls        | /lib/x86_64-linux-gnu/libc-2.31.so             | 1     | Mon Mar  6 18:01:28 UTC 2023 | Allow  |
| /bin/ls        | /lib/x86_64-linux-gnu/libpthread-2.31.so       | 1     | Mon Mar  6 18:01:28 UTC 2023 | Allow  |
| /bin/ls        | /lib/x86_64-linux-gnu/libselinux.so.1          | 1     | Mon Mar  6 18:01:28 UTC 2023 | Allow  |
| /bin/ls        | /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.10.1 | 1     | Mon Mar  6 18:01:28 UTC 2023 | Allow  |
| /usr/bin/clear | /lib/terminfo/x/xterm                          | 1     | Mon Mar  6 18:01:30 UTC 2023 | Allow  |
| /usr/bin/clear | /lib/x86_64-linux-gnu/libtinfo.so.6.2          | 1     | Mon Mar  6 18:01:30 UTC 2023 | Allow  |
+----------------+------------------------------------------------+-------+------------------------------+--------+

```

```bash
$ karmor summary -p nginx --container redis
local port to be used for port forwarding discovery-engine-68bfd8f58-ghqsg: 32792 

  Pod Name        nginx      
  Namespace Name  default    
  Cluster Name    default    
  Container Name  redis      
  Labels          run=nginx  

Process Data
+-------------+--------------------------+-------+------------------------------+--------+
| SRC PROCESS | DESTINATION PROCESS PATH | COUNT |      LAST UPDATED TIME       | STATUS |
+-------------+--------------------------+-------+------------------------------+--------+
| /bin/bash   | /bin/ls                  | 1     | Mon Mar  6 18:01:20 UTC 2023 | Allow  |
+-------------+--------------------------+-------+------------------------------+--------+


File Data
+-------------+------------------------------------------------+-------+------------------------------+--------+
| SRC PROCESS |             DESTINATION FILE PATH              | COUNT |      LAST UPDATED TIME       | STATUS |
+-------------+------------------------------------------------+-------+------------------------------+--------+
| /bin/bash   | /etc/bash.bashrc                               | 1     | Mon Mar  6 18:01:19 UTC 2023 | Allow  |
| /bin/bash   | /etc/ld.so.cache                               | 1     | Mon Mar  6 18:01:19 UTC 2023 | Allow  |
| /bin/bash   | /etc/nsswitch.conf                             | 1     | Mon Mar  6 18:01:19 UTC 2023 | Allow  |
| /bin/bash   | /etc/passwd                                    | 1     | Mon Mar  6 18:01:19 UTC 2023 | Allow  |
| /bin/bash   | /lib/terminfo/x/xterm                          | 1     | Mon Mar  6 18:01:19 UTC 2023 | Allow  |
| /bin/bash   | /lib/x86_64-linux-gnu/libc-2.31.so             | 1     | Mon Mar  6 18:01:19 UTC 2023 | Allow  |
| /bin/bash   | /lib/x86_64-linux-gnu/libnss_files-2.31.so     | 1     | Mon Mar  6 18:01:19 UTC 2023 | Allow  |
| /bin/bash   | /root/.bash_history                            | 2     | Mon Mar  6 18:01:24 UTC 2023 | Allow  |
| /bin/bash   | /root/.bashrc                                  | 1     | Mon Mar  6 18:01:19 UTC 2023 | Allow  |
| /bin/ls     | /data                                          | 1     | Mon Mar  6 18:01:20 UTC 2023 | Allow  |
| /bin/ls     | /etc/ld.so.cache                               | 1     | Mon Mar  6 18:01:20 UTC 2023 | Allow  |
| /bin/ls     | /lib/x86_64-linux-gnu/libdl-2.31.so            | 1     | Mon Mar  6 18:01:20 UTC 2023 | Allow  |
| /bin/ls     | /lib/x86_64-linux-gnu/libpthread-2.31.so       | 1     | Mon Mar  6 18:01:20 UTC 2023 | Allow  |
| /bin/ls     | /usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.10.1 | 1     | Mon Mar  6 18:01:20 UTC 2023 | Allow  |
+-------------+------------------------------------------------+-------+------------------------------+--------+
```