### PR TITLE
update goreleaser for cosign 2.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,13 +14,12 @@ builds:
 
 signs:
   - cmd: cosign
-    env:
-      - COSIGN_EXPERIMENTAL=1
     certificate: '${artifact}.cert'
     args:
       - sign-blob
       - '--output-certificate=${certificate}' 
       - '--output-signature=${signature}'
       - '${artifact}'
+      - --yes
     artifacts: all
     output: true


### PR DESCRIPTION
- This PR is modifying the .goreleaser file for cosign 2.0 
- Please check this release on my playground repo [here](https://github.com/kranurag78/kubearmor-client/releases/tag/v0.12.1)