### PR TITLE
Decouple logic for updating policy rules

### DIFF
--- a/recommend/policy.go
+++ b/recommend/policy.go
@@ -153,8 +153,8 @@ func (img *ImageInfo) getPolicyFromImageInfo() {
 		log.Infof("No runtime policy generated for %s/%s/%s", img.Namespace, img.Deployment, img.Name)
 	}
 
-	ms, err = getNextRule(&idx)
-	for ; err == nil; ms, err = getNextRule(&idx) {
+	ms, err = getNextRule(&idx, policyRules)
+	for ; err == nil; ms, err = getNextRule(&idx, policyRules) {
 		// matches preconditions
 
 		if !matchTags(ms) {


### PR DESCRIPTION
Signed-off-by: Vyom-Yadav [jackhammervyom@gmail.com](mailto:jackhammervyom@gmail.com)

### Rationale:

The global variable `var policyRules []MatchSpec` was updated by several functions, both directly and indirectly.

The following pattern passes a pointer to the particular variable which in turn updates the global variable. Logically nothing changes but functions now don't depend on the global variables and can be used in both `kuberarmor-client` and `discovery-engine` (both have some duplicated logic).

Since the addition of admission controller policies is under progress, this will ensure that we have one place for the code which can be imported by the other project or by both the project.

### Feedback and suggestions required:

1. General review of changes.
2. More methods are common and can be extracted to a common place (no need to modify them), where should this code be kept?

We can either have a separate util repo or keep the code in the current repo only and the `discovery-engine` can import it.
