### PR TITLE
fix(logClient.go):fix panic interface conversion: interface {} is nil not string

### DIFF
--- a/log/logClient.go
+++ b/log/logClient.go
@@ -298,10 +298,10 @@ func WatchTelemetryHelper(arr []byte, t string, o Options) {
 	if err != nil {
 		return
 	}
-
 	// Filter Telemetry based on provided options
-	if len(o.Selector) != 0 {
-		val := selectLabels(o, res["Labels"].(string))
+	if len(o.Selector) != 0 && res["Labels"] != nil {
+		labels := strings.Split(res["Labels"].(string), ",")
+		val := selectLabels(o, labels)
 		if val != nil {
 			return
 		}
@@ -465,11 +465,14 @@ func (fd *Feeder) DestroyClient() error {
 	return nil
 }
 
-func selectLabels(o Options, labels string) error {
+func selectLabels(o Options, labels []string) error {
 	for _, val := range o.Selector {
-		if val == labels {
-			return nil
+		for _, label := range labels {
+			if val == label {
+				return nil
+			}
 		}
+
 	}
 	return errors.New("Not found any flag")
 }

--- a/log/logClient_test.go
+++ b/log/logClient_test.go
@@ -50,6 +50,7 @@ func TestLogClient(t *testing.T) {
 	eventChan = make(chan EventInfo, maxEvents)
 	var o = Options{
 		EventChan: eventChan,
+		Selector:  []string{"substance=meth"},
 	}
 
 	tel, err := json.Marshal(res)


### PR DESCRIPTION
fix #290 
### First
wrong code: https://github.com/kubearmor/kubearmor-client/blob/main/log/logClient.go#L304
```
func WatchTelemetryHelper(arr []byte, t string, o Options) {
	var res map[string]interface{}
	err := json.Unmarshal(arr, &res)
	if err != nil {
		return
	}

	// Filter Telemetry based on provided options
	if len(o.Selector) != 0 {
304		val := selectLabels(o, res["Labels"].(string))
		if val != nil {
			return
		}
	}

	if o.Namespace != "" {
		ns, ok := res["NamespaceName"].(string)
		if !ok {
			return
		}
		match := regexMatcher(CNamespace, ns)
		if !match {
			return
		}
	}

```
some time `len(o.Selector)` != 0  but `res["Labels"]` is nil, will lead to panic.
### Second

if `o.Selector` match one label should select it ? so i use `labels := strings.Split(res["Labels"].(string), ",")` to split multiple labels.