### PR TITLE
`karmor probe` output in json format

### DIFF
--- a/cmd/probe.go
+++ b/cmd/probe.go
@@ -22,10 +22,9 @@ and what KubeArmor features will be supported e.g: observability, enforcement, e
 If KubeArmor is running, It probes which environment KubeArmor is running on (e.g: systemd mode, kubernetes etc.), 
 the supported KubeArmor features in the environment, the pods being handled by KubeArmor and the policies running on each of these pods`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := probe.PrintProbeResult(client, probeInstallOptions); err != nil {
-			return err
-		}
-		return nil
+
+		err := probe.PrintProbeResult(client, probeInstallOptions)
+		return err
 
 	},
 }
@@ -35,4 +34,5 @@ func init() {
 	probeCmd.Flags().StringVarP(&probeInstallOptions.Namespace, "namespace", "n", "kube-system", "Namespace for resources")
 	probeCmd.Flags().BoolVar(&probeInstallOptions.Full, "full", false, `If KubeArmor is not running, it deploys a daemonset to have access to more
 information on KubeArmor support in the environment and deletes daemonset after probing`)
+	probeCmd.Flags().StringVarP(&probeInstallOptions.Output, "format", "f", "text", " Format: json or text ")
 }

--- a/install/install.go
+++ b/install/install.go
@@ -152,7 +152,7 @@ func checkPods(c *k8s.Client, o Options) {
 			fmt.Print("⚠️\tFailed verifying KubeArmor functionality ...")
 			return
 		}
-		probeData, err := probe.ProbeRunningKubeArmorNodes(c, probe.Options{
+		probeData, _, err := probe.ProbeRunningKubeArmorNodes(c, probe.Options{
 			Namespace: o.Namespace,
 		})
 		if err != nil || len(probeData) == 0 {

--- a/probe/print.go
+++ b/probe/print.go
@@ -1,0 +1,116 @@
+package probe
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/fatih/color"
+	"github.com/olekukonko/tablewriter"
+)
+
+func renderOutputInTableWithNoBorders(data [][]string) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+	table.AppendBulk(data) // Add Bulk Data
+	table.Render()
+}
+
+// printDaemonsetData function
+func printDaemonsetData(daemonsetStatus *Status) {
+	var data [][]string
+
+	color.Green("\nFound KubeArmor running in Kubernetes\n\n")
+	_, err := boldWhite.Printf("Daemonset :\n")
+	if err != nil {
+		color.Red(" Error while printing")
+	}
+	data = append(data, []string{" ", "kubearmor ", "Desired: " + daemonsetStatus.Desired, "Ready: " + daemonsetStatus.Ready, "Available: " + daemonsetStatus.Available})
+	renderOutputInTableWithNoBorders(data)
+}
+
+// printKubeArmorDeployments function
+func printKubearmorDeployments(deploymentData map[string]*Status) {
+
+	_, err := boldWhite.Printf("Deployments : \n")
+	if err != nil {
+		color.Red(" Error while printing")
+	}
+	var data [][]string
+	for depName, depStatus := range deploymentData {
+		data = append(data, []string{" ", depName, "Desired: " + depStatus.Desired, "Ready: " + depStatus.Ready, "Available: " + depStatus.Available})
+	}
+
+	renderOutputInTableWithNoBorders(data)
+}
+
+// printKubeArmorContainers function
+func printKubeArmorContainers(containerData map[string]*KubeArmorPodSpec) {
+	var data [][]string
+
+	_, err := boldWhite.Printf("Containers : \n")
+	if err != nil {
+		color.Red(" Error while printing")
+	}
+	for name, spec := range containerData {
+
+		data = append(data, []string{" ", name, "Running: " + spec.Running, "Image Version: " + spec.Image_Version})
+	}
+	renderOutputInTableWithNoBorders(data)
+}
+
+// printKubeArmorprobe function
+func printKubeArmorprobe(probeData []KubeArmorProbeData) {
+
+	for i, pd := range probeData {
+		_, err := boldWhite.Printf("Node %d : \n", i+1)
+		if err != nil {
+			color.Red(" Error")
+		}
+		printKubeArmorProbeOutput(pd)
+	}
+
+}
+
+// printKubeArmorProbeOutput function
+func printKubeArmorProbeOutput(kd KubeArmorProbeData) {
+	var data [][]string
+	data = append(data, []string{" ", "OS Image:", green(kd.OSImage)})
+	data = append(data, []string{" ", "Kernel Version:", green(kd.KernelVersion)})
+	data = append(data, []string{" ", "Kubelet Version:", green(kd.KubeletVersion)})
+	data = append(data, []string{" ", "Container Runtime:", green(kd.ContainerRuntime)})
+	data = append(data, []string{" ", "Active LSM:", green(kd.ActiveLSM)})
+	data = append(data, []string{" ", "Host Security:", green(strconv.FormatBool(kd.HostSecurity))})
+	data = append(data, []string{" ", "Container Security:", green(strconv.FormatBool(kd.ContainerSecurity))})
+	data = append(data, []string{" ", "Container Default Posture:", green(kd.ContainerDefaultPosture.FileAction) + itwhite("(File)"), green(kd.ContainerDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.ContainerDefaultPosture.NetworkAction) + itwhite("(Network)")})
+	data = append(data, []string{" ", "Host Default Posture:", green(kd.HostDefaultPosture.FileAction) + itwhite("(File)"), green(kd.HostDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.HostDefaultPosture.NetworkAction) + itwhite("(Network)")})
+	data = append(data, []string{" ", "Host Visibility:", green(kd.HostVisibility)})
+	renderOutputInTableWithNoBorders(data)
+}
+
+// printAnnotatedPods function
+func printAnnotatedPods(podData [][]string) {
+
+	_, err := boldWhite.Printf("Armored Up pods : \n")
+	if err != nil {
+		color.Red(" Error printing bold text")
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"NAMESPACE", "DEFAULT POSTURE", "VISIBILITY", "NAME", "POLICY"})
+	for _, v := range podData {
+		table.Append(v)
+	}
+	table.SetRowLine(true)
+	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2})
+	table.Render()
+}

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -48,6 +48,12 @@ type Options struct {
 	Full      bool
 }
 
+// To store container default posture and visibility data
+type PostureAndVisibility struct {
+	DefaultPosture string
+	Visibility     string
+}
+
 // K8sInstaller for karmor install
 func probeDaemonInstaller(c *k8s.Client, o Options, krnhdr bool) error {
 	daemonset := deployment.GenerateDaemonSet(o.Namespace, krnhdr)
@@ -517,6 +523,8 @@ func readDataFromKubeArmor(c *k8s.Client, o Options, nodeName string) (KubeArmor
 	}
 	return kd, nil
 }
+func parseJsonData(buf []byte) (*KubeArmorProbeData, error) {
+	// Parsing JSON encoded data
 
 func printKubeArmorProbeOutput(kd KubeArmorProbeData) {
 	var data [][]string
@@ -527,7 +535,7 @@ func printKubeArmorProbeOutput(kd KubeArmorProbeData) {
 	data = append(data, []string{" ", "Active LSM:", green(kd.ActiveLSM)})
 	data = append(data, []string{" ", "Host Security:", green(strconv.FormatBool(kd.HostSecurity))})
 	data = append(data, []string{" ", "Container Security:", green(strconv.FormatBool(kd.ContainerSecurity))})
-	data = append(data, []string{" ", "Container Default Posture:", green(kd.ContainerDefaultPosture.FileAction) + itwhite("(File)"), green(kd.ContainerDefaultPosture.FileAction) + itwhite("(Capabilities)"), green(kd.ContainerDefaultPosture.NetworkAction) + itwhite("(Network)")})
+	data = append(data, []string{" ", "Container Default Posture:", green(kd.ContainerDefaultPosture.FileAction) + itwhite("(File)"), green(kd.ContainerDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.ContainerDefaultPosture.NetworkAction) + itwhite("(Network)")})
 	data = append(data, []string{" ", "Host Default Posture:", green(kd.HostDefaultPosture.FileAction) + itwhite("(File)"), green(kd.HostDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.HostDefaultPosture.NetworkAction) + itwhite("(Network)")})
 	data = append(data, []string{" ", "Host Visibility:", green(kd.HostVisibility)})
 	renderOutputInTableWithNoBorders(data)
@@ -579,10 +587,48 @@ func getAnnotatedPodLabels(m map[string]string) mapset.Set[string] {
 	return b
 }
 
-func getAnnotatedPods(c *k8s.Client) error {
+func getNsSecurityPostureAndVisibility(c *k8s.Client, postureData map[string]string) (map[string]*PostureAndVisibility, error) {
+	// Namespace/host security posture and visibility setting
+
+	mp := make(map[string]*PostureAndVisibility)
+	namespaces, err := c.K8sClientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+
+	if err != nil {
+		return mp, err
+	}
+
+	for _, ns := range namespaces.Items {
+
+		filePosture := postureData["filePosture"]
+		capabilityPosture := postureData["capabilitiesPosture"]
+		networkPosture := postureData["networkPosture"]
+
+		if len(ns.Annotations["kubearmor-file-posture"]) > 0 {
+			filePosture = ns.Annotations["kubearmor-file-posture"]
+		}
+
+		if len(ns.Annotations["kubearmor-capabilities-posture"]) > 0 {
+			capabilityPosture = ns.Annotations["kubearmor-capabilities-posture"]
+		}
+
+		if len(ns.Annotations["kubearmor-network-posture"]) > 0 {
+			networkPosture = ns.Annotations["kubearmor-network-posture"]
+		}
+		mp[ns.Name] = &PostureAndVisibility{DefaultPosture: "file(" + filePosture + "), capabilities(" + capabilityPosture + "), network(" + networkPosture + ")", Visibility: ns.Annotations["kubearmor-visibility"]}
+	}
+
+	return mp, err
+}
+
+func getAnnotatedPods(c *k8s.Client, postureData map[string]string) error {
 	// Annotated Pods Description
 	var data [][]string
 	pods, err := c.K8sClientset.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	mp, err := getNsSecurityPostureAndVisibility(c, postureData)
 	if err != nil {
 		return err
 	}
@@ -593,20 +639,23 @@ func getAnnotatedPods(c *k8s.Client) error {
 	}
 
 	for _, p := range pods.Items {
+
 		if p.Annotations["kubearmor-policy"] == "enabled" {
 			armoredPod, err := c.K8sClientset.CoreV1().Pods(p.Namespace).Get(context.Background(), p.Name, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
-			data = append(data, []string{armoredPod.Namespace, armoredPod.Name, ""})
+			data = append(data, []string{armoredPod.Namespace, mp[armoredPod.Namespace].DefaultPosture, mp[armoredPod.Namespace].Visibility, armoredPod.Name, ""})
 			labels := getAnnotatedPodLabels(armoredPod.Labels)
+
 			for policyKey, policyValue := range policyMap {
 				s2 := sliceToSet(policyValue)
 				if s2.IsSubset(labels) {
 					if checkIfDataAlreadyContainsPodName(data, armoredPod.Name, policyKey) {
 						continue
 					} else {
-						data = append(data, []string{armoredPod.Namespace, armoredPod.Name, policyKey})
+						data = append(data, []string{armoredPod.Namespace, mp[armoredPod.Namespace].DefaultPosture, mp[armoredPod.Namespace].Visibility, armoredPod.Name, policyKey})
+
 					}
 				}
 			}
@@ -623,13 +672,13 @@ func getAnnotatedPods(c *k8s.Client) error {
 	})
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"NAMESPACE", "NAME", "POLICY"})
+	table.SetHeader([]string{"NAMESPACE", "DEFAULT POSTURE", "VISIBILITY", "NAME", "POLICY"})
 
 	for _, v := range data {
 		table.Append(v)
 	}
 	table.SetRowLine(true)
-	table.SetAutoMergeCellsByColumnIndex([]int{0, 1})
+	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2})
 	table.Render()
 	return nil
 }
@@ -673,10 +722,10 @@ func checkIfDataAlreadyContainsPodName(input [][]string, name string, policy str
 	for _, slice := range input {
 		//if slice contains podname, then append the policy to the existing policies
 		if slices.Contains(slice, name) {
-			if slice[2] == "" {
-				slice[2] = policy
+			if slice[4] == "" {
+				slice[4] = policy
 			} else {
-				slice[2] = slice[2] + "\n" + policy
+				slice[4] = slice[4] + "\n" + policy
 			}
 			return true
 		}

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -7,6 +7,7 @@ package probe
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -24,7 +25,7 @@ import (
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 	"github.com/kubearmor/kubearmor-client/deployment"
 	"github.com/kubearmor/kubearmor-client/k8s"
-	"github.com/olekukonko/tablewriter"
+
 	"golang.org/x/exp/slices"
 	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
@@ -41,18 +42,6 @@ var white = color.New(color.FgWhite)
 var boldWhite = white.Add(color.Bold)
 var green = color.New(color.FgGreen).SprintFunc()
 var itwhite = color.New(color.Italic).Add(color.Italic).SprintFunc()
-
-// Options provides probe daemonset options install
-type Options struct {
-	Namespace string
-	Full      bool
-}
-
-// To store container default posture and visibility data
-type PostureAndVisibility struct {
-	DefaultPosture string
-	Visibility     string
-}
 
 // K8sInstaller for karmor install
 func probeDaemonInstaller(c *k8s.Client, o Options, krnhdr bool) error {
@@ -92,24 +81,41 @@ func PrintProbeResult(c *k8s.Client, o Options) error {
 		}
 		return nil
 	}
-	if isKubeArmorRunning(c, o) {
-		getKubeArmorDeployments(c, o)
-		getKubeArmorContainers(c, o)
-		probeData, err := ProbeRunningKubeArmorNodes(c, o)
+	isRunning, daemonsetStatus := isKubeArmorRunning(c, o)
+	if isRunning {
+		deploymentData := getKubeArmorDeployments(c, o)
+		containerData := getKubeArmorContainers(c, o)
+		probeData, nodeData, err := ProbeRunningKubeArmorNodes(c, o)
 		if err != nil {
 			log.Println("error occured when probing kubearmor nodes", err)
 		}
-		for i, pd := range probeData {
-			_, err := boldWhite.Printf("Node %d : \n", i+1)
-			if err != nil {
-				color.Red(" Error")
-			}
-			printKubeArmorProbeOutput(pd)
-		}
-		err = getAnnotatedPods(c)
+		postureData := getPostureData(probeData)
+		armoredPodData, podData, err := getAnnotatedPods(c, o, postureData)
 		if err != nil {
 			log.Println("error occured when getting annotated pods", err)
 		}
+		if o.Output == "json" {
+			ProbeData := map[string]interface{}{"Probe Data": map[string]interface{}{
+				"DaemonsetStatus": daemonsetStatus,
+				"Deployments":     deploymentData,
+				"Containers":      containerData,
+				"Nodes":           nodeData,
+				"ArmoredPods":     armoredPodData,
+			},
+			}
+			out, err := json.Marshal(ProbeData)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(out))
+		} else {
+			printDaemonsetData(daemonsetStatus)
+			printKubearmorDeployments(deploymentData)
+			printKubeArmorContainers(containerData)
+			printKubeArmorprobe(probeData)
+			printAnnotatedPods(podData)
+		}
+
 		return nil
 	}
 
@@ -360,119 +366,109 @@ func probeNode(c *k8s.Client, o Options) {
 	}
 }
 
-// KubeArmorProbeData structure definition
-type KubeArmorProbeData struct {
-	OSImage                 string
-	KernelVersion           string
-	KubeletVersion          string
-	ContainerRuntime        string
-	ActiveLSM               string
-	KernelHeaderPresent     bool
-	HostSecurity            bool
-	ContainerSecurity       bool
-	ContainerDefaultPosture tp.DefaultPosture
-	HostDefaultPosture      tp.DefaultPosture
-	HostVisibility          string
-}
-
-func isKubeArmorRunning(c *k8s.Client, o Options) bool {
-	_, err := getKubeArmorDaemonset(c, o)
-	return err == nil
+func isKubeArmorRunning(c *k8s.Client, o Options) (bool, *Status) {
+	isRunning, DaemonsetStatus := getKubeArmorDaemonset(c, o)
+	return isRunning, DaemonsetStatus
 
 }
 
-func getKubeArmorDaemonset(c *k8s.Client, o Options) (bool, error) {
-	var data [][]string
+func getKubeArmorDaemonset(c *k8s.Client, o Options) (bool, *Status) {
+
 	// KubeArmor DaemonSet
 	w, err := c.K8sClientset.AppsV1().DaemonSets(o.Namespace).Get(context.Background(), "kubearmor", metav1.GetOptions{})
 	if err != nil {
-		return false, err
-	}
-	color.Green("\nFound KubeArmor running in Kubernetes\n\n")
-	_, err = boldWhite.Printf("Daemonset :\n")
-	if err != nil {
-		color.Red(" Error while printing")
+		log.Println("error when getting kubearmor daemonset", err)
+		return false, nil
 	}
 	desired, ready, available := w.Status.DesiredNumberScheduled, w.Status.NumberReady, w.Status.NumberAvailable
 	if desired != ready && desired != available {
 		return false, nil
 	}
-	data = append(data, []string{" ", "kubearmor ", "Desired: " + strconv.Itoa(int(desired)), "Ready: " + strconv.Itoa(int(ready)), "Available: " + strconv.Itoa(int(available))})
-	renderOutputInTableWithNoBorders(data)
-	return true, nil
-}
-func getKubeArmorDeployments(c *k8s.Client, o Options) {
-	var data [][]string
-	_, err := boldWhite.Printf("Deployments : \n")
-	if err != nil {
-		color.Red(" Error while printing")
+
+	DaemonSetStatus := Status{
+		Desired:   strconv.Itoa(int(desired)),
+		Ready:     strconv.Itoa(int(ready)),
+		Available: strconv.Itoa(int(available)),
 	}
+	return true, &DaemonSetStatus
+
+}
+func getKubeArmorDeployments(c *k8s.Client, o Options) map[string]*Status {
+
 	kubearmorDeployments, err := c.K8sClientset.AppsV1().Deployments(o.Namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: "kubearmor-app",
 	})
-
 	if err != nil {
-		return
+		log.Println("error while getting kubearmor deployments", err)
+		return nil
 	}
 	if len(kubearmorDeployments.Items) > 0 {
+		DeploymentsData := make(map[string]*Status)
 		for _, kubearmorDeploymentItem := range kubearmorDeployments.Items {
 			desired, ready, available := kubearmorDeploymentItem.Status.UpdatedReplicas, kubearmorDeploymentItem.Status.ReadyReplicas, kubearmorDeploymentItem.Status.AvailableReplicas
-			if desired != ready && desired != available {
-				continue
-			} else {
-				data = append(data, []string{" ", kubearmorDeploymentItem.Name, "Desired: " + strconv.Itoa(int(desired)), "Ready: " + strconv.Itoa(int(ready)), "Available: " + strconv.Itoa(int(available))})
+			if desired == ready && desired == available {
+				DeploymentsData[kubearmorDeploymentItem.Name] = &Status{
+					Desired:   strconv.Itoa(int(desired)),
+					Ready:     strconv.Itoa(int(ready)),
+					Available: strconv.Itoa(int(available)),
+				}
 			}
 		}
+
+		return DeploymentsData
 	}
-	renderOutputInTableWithNoBorders(data)
+	return nil
 }
 
-func getKubeArmorContainers(c *k8s.Client, o Options) {
-	var data [][]string
-	_, err := boldWhite.Printf("Containers : \n")
-	if err != nil {
-		color.Red(" Error while printing")
-	}
+func getKubeArmorContainers(c *k8s.Client, o Options) map[string]*KubeArmorPodSpec {
+
 	kubearmorPods, err := c.K8sClientset.CoreV1().Pods(o.Namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: "kubearmor-app",
 	})
+
 	if err != nil {
 		log.Println("error occured when getting kubearmor pods", err)
-		return
+		return nil
 	}
-
+	KAContainerData := make(map[string]*KubeArmorPodSpec)
 	if len(kubearmorPods.Items) > 0 {
 		for _, kubearmorPodItem := range kubearmorPods.Items {
-			data = append(data, []string{" ", kubearmorPodItem.Name, "Running: " + strconv.Itoa(len(kubearmorPodItem.Spec.Containers)), "Image Version: " + kubearmorPodItem.Spec.Containers[0].Image})
+
+			KAContainerData[kubearmorPodItem.Name] = &KubeArmorPodSpec{
+				Running:       strconv.Itoa(len(kubearmorPodItem.Spec.Containers)),
+				Image_Version: kubearmorPodItem.Spec.Containers[0].Image,
+			}
 		}
+
+		return KAContainerData
 	}
-
-	renderOutputInTableWithNoBorders(data)
-
+	return nil
 }
 
 // ProbeRunningKubeArmorNodes extracts data from running KubeArmor daemonset  by executing into the container and reading /tmp/kubearmor.cfg
-func ProbeRunningKubeArmorNodes(c *k8s.Client, o Options) ([]KubeArmorProbeData, error) {
+func ProbeRunningKubeArmorNodes(c *k8s.Client, o Options) ([]KubeArmorProbeData, map[string]KubeArmorProbeData, error) {
 	// KubeArmor Nodes
 	nodes, err := c.K8sClientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return []KubeArmorProbeData{}, fmt.Errorf("error occured when getting nodes %s", err.Error())
+		return []KubeArmorProbeData{}, nil, fmt.Errorf("error occured when getting nodes %s", err.Error())
 	}
 
 	if len(nodes.Items) == 0 {
-		return []KubeArmorProbeData{}, fmt.Errorf("no nodes found")
+		return []KubeArmorProbeData{}, nil, fmt.Errorf("no nodes found")
 	}
+	nodeData := make(map[string]KubeArmorProbeData)
 
 	var dataList []KubeArmorProbeData
-	for _, item := range nodes.Items {
+	for i, item := range nodes.Items {
 		data, err := readDataFromKubeArmor(c, o, item.Name)
 		if err != nil {
-			return []KubeArmorProbeData{}, err
+			return []KubeArmorProbeData{}, nil, err
 		}
 		dataList = append(dataList, data)
+		nodeData["Node"+strconv.Itoa(i+1)] = data
 	}
 
-	return dataList, nil
+	return dataList, nodeData, nil
 }
 
 func readDataFromKubeArmor(c *k8s.Client, o Options, nodeName string) (KubeArmorProbeData, error) {
@@ -523,22 +519,15 @@ func readDataFromKubeArmor(c *k8s.Client, o Options, nodeName string) (KubeArmor
 	}
 	return kd, nil
 }
-func parseJsonData(buf []byte) (*KubeArmorProbeData, error) {
-	// Parsing JSON encoded data
+func getPostureData(probeData []KubeArmorProbeData) map[string]string {
+	postureData := make(map[string]string)
+	if len(probeData) > 0 {
+		postureData["filePosture"] = probeData[0].ContainerDefaultPosture.FileAction
+		postureData["capabilitiesPosture"] = probeData[0].ContainerDefaultPosture.CapabilitiesAction
+		postureData["networkPosture"] = probeData[0].ContainerDefaultPosture.NetworkAction
+	}
 
-func printKubeArmorProbeOutput(kd KubeArmorProbeData) {
-	var data [][]string
-	data = append(data, []string{" ", "OS Image:", green(kd.OSImage)})
-	data = append(data, []string{" ", "Kernel Version:", green(kd.KernelVersion)})
-	data = append(data, []string{" ", "Kubelet Version:", green(kd.KubeletVersion)})
-	data = append(data, []string{" ", "Container Runtime:", green(kd.ContainerRuntime)})
-	data = append(data, []string{" ", "Active LSM:", green(kd.ActiveLSM)})
-	data = append(data, []string{" ", "Host Security:", green(strconv.FormatBool(kd.HostSecurity))})
-	data = append(data, []string{" ", "Container Security:", green(strconv.FormatBool(kd.ContainerSecurity))})
-	data = append(data, []string{" ", "Container Default Posture:", green(kd.ContainerDefaultPosture.FileAction) + itwhite("(File)"), green(kd.ContainerDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.ContainerDefaultPosture.NetworkAction) + itwhite("(Network)")})
-	data = append(data, []string{" ", "Host Default Posture:", green(kd.HostDefaultPosture.FileAction) + itwhite("(File)"), green(kd.HostDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.HostDefaultPosture.NetworkAction) + itwhite("(Network)")})
-	data = append(data, []string{" ", "Host Visibility:", green(kd.HostVisibility)})
-	renderOutputInTableWithNoBorders(data)
+	return postureData
 }
 
 // sudo systemctl status kubearmor
@@ -587,16 +576,15 @@ func getAnnotatedPodLabels(m map[string]string) mapset.Set[string] {
 	return b
 }
 
-func getNsSecurityPostureAndVisibility(c *k8s.Client, postureData map[string]string) (map[string]*PostureAndVisibility, error) {
+func getNsSecurityPostureAndVisibility(c *k8s.Client, postureData map[string]string) (map[string]*NamespaceData, error) {
 	// Namespace/host security posture and visibility setting
 
-	mp := make(map[string]*PostureAndVisibility)
+	mp := make(map[string]*NamespaceData)
 	namespaces, err := c.K8sClientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
 
 	if err != nil {
 		return mp, err
 	}
-
 	for _, ns := range namespaces.Items {
 
 		filePosture := postureData["filePosture"]
@@ -614,23 +602,35 @@ func getNsSecurityPostureAndVisibility(c *k8s.Client, postureData map[string]str
 		if len(ns.Annotations["kubearmor-network-posture"]) > 0 {
 			networkPosture = ns.Annotations["kubearmor-network-posture"]
 		}
-		mp[ns.Name] = &PostureAndVisibility{DefaultPosture: "file(" + filePosture + "), capabilities(" + capabilityPosture + "), network(" + networkPosture + ")", Visibility: ns.Annotations["kubearmor-visibility"]}
-	}
 
+		mp[ns.Name] = &NamespaceData{
+			NsDefaultPosture:   tp.DefaultPosture{FileAction: filePosture, CapabilitiesAction: capabilityPosture, NetworkAction: networkPosture},
+			NsVisibilityString: ns.Annotations["kubearmor-visibility"],
+			NsVisibility: Visibility{
+				Process:      strings.Contains(ns.Annotations["kubearmor-visibility"], "process"),
+				File:         strings.Contains(ns.Annotations["kubearmor-visibility"], "file"),
+				Network:      strings.Contains(ns.Annotations["kubearmor-visibility"], "network"),
+				Capabilities: strings.Contains(ns.Annotations["kubearmor-visibility"], "capabilities"),
+			},
+			NsPostureString: "File(" + filePosture + "), Capabilities(" + capabilityPosture + "), Network (" + networkPosture + ")",
+		}
+	}
 	return mp, err
 }
 
-func getAnnotatedPods(c *k8s.Client, postureData map[string]string) error {
+func getAnnotatedPods(c *k8s.Client, o Options, postureData map[string]string) (map[string]interface{}, [][]string, error) {
+
 	// Annotated Pods Description
 	var data [][]string
 	pods, err := c.K8sClientset.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return err
+		return nil, [][]string{}, err
 	}
 
+	armoredPodData := make(map[string]*NamespaceData)
 	mp, err := getNsSecurityPostureAndVisibility(c, postureData)
 	if err != nil {
-		return err
+		return nil, [][]string{}, err
 	}
 
 	policyMap, err := getPoliciesOnAnnotatedPods(c)
@@ -643,44 +643,40 @@ func getAnnotatedPods(c *k8s.Client, postureData map[string]string) error {
 		if p.Annotations["kubearmor-policy"] == "enabled" {
 			armoredPod, err := c.K8sClientset.CoreV1().Pods(p.Namespace).Get(context.Background(), p.Name, metav1.GetOptions{})
 			if err != nil {
-				return err
+				return nil, [][]string{}, err
 			}
-			data = append(data, []string{armoredPod.Namespace, mp[armoredPod.Namespace].DefaultPosture, mp[armoredPod.Namespace].Visibility, armoredPod.Name, ""})
+			data = append(data, []string{armoredPod.Namespace, mp[armoredPod.Namespace].NsPostureString, mp[armoredPod.Namespace].NsVisibilityString, armoredPod.Name, ""})
 			labels := getAnnotatedPodLabels(armoredPod.Labels)
 
 			for policyKey, policyValue := range policyMap {
 				s2 := sliceToSet(policyValue)
 				if s2.IsSubset(labels) {
-					if checkIfDataAlreadyContainsPodName(data, armoredPod.Name, policyKey) {
-						continue
-					} else {
-						data = append(data, []string{armoredPod.Namespace, mp[armoredPod.Namespace].DefaultPosture, mp[armoredPod.Namespace].Visibility, armoredPod.Name, policyKey})
+					if !checkIfDataAlreadyContainsPodName(data, armoredPod.Name, policyKey) {
+
+						data = append(data, []string{armoredPod.Namespace, mp[armoredPod.Namespace].NsPostureString, mp[armoredPod.Namespace].NsVisibilityString, armoredPod.Name, policyKey})
 
 					}
 				}
 			}
 		}
 	}
-	_, err = boldWhite.Printf("Armored Up pods : \n")
-	if err != nil {
-		color.Red(" Error printing bold text")
-	}
-
 	// sorting according to namespaces, for merging of cells with same namespaces
 	sort.SliceStable(data, func(i, j int) bool {
 		return data[i][0] < data[j][0]
 	})
 
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"NAMESPACE", "DEFAULT POSTURE", "VISIBILITY", "NAME", "POLICY"})
-
 	for _, v := range data {
-		table.Append(v)
+
+		if _, exists := armoredPodData[v[0]]; !exists {
+			armoredPodData[v[0]] = &NamespaceData{
+				NsDefaultPosture: mp[v[0]].NsDefaultPosture,
+				NsVisibility:     mp[v[0]].NsVisibility,
+			}
+		}
+		armoredPodData[v[0]].NsPodList = append(armoredPodData[v[0]].NsPodList, PodInfo{PodName: v[3], Policy: v[4]})
 	}
-	table.SetRowLine(true)
-	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2})
-	table.Render()
-	return nil
+
+	return map[string]interface{}{"Namespaces": armoredPodData}, data, nil
 }
 
 func getPoliciesOnAnnotatedPods(c *k8s.Client) (map[string][]string, error) {
@@ -700,24 +696,6 @@ func getPoliciesOnAnnotatedPods(c *k8s.Client) (map[string][]string, error) {
 	}
 	return maps, nil
 }
-
-func renderOutputInTableWithNoBorders(data [][]string) {
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
-	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetCenterSeparator("")
-	table.SetColumnSeparator("")
-	table.SetRowSeparator("")
-	table.SetHeaderLine(false)
-	table.SetBorder(false)
-	table.SetTablePadding("\t") // pad with tabs
-	table.SetNoWhiteSpace(true)
-	table.AppendBulk(data) // Add Bulk Data
-	table.Render()
-}
-
 func checkIfDataAlreadyContainsPodName(input [][]string, name string, policy string) bool {
 	for _, slice := range input {
 		//if slice contains podname, then append the policy to the existing policies

--- a/probe/types.go
+++ b/probe/types.go
@@ -1,0 +1,63 @@
+package probe
+
+import (
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+// Options provides probe daemonset options install
+type Options struct {
+	Namespace string
+	Full      bool
+	Output    string
+}
+
+// KubeArmorProbeData structure definition
+type KubeArmorProbeData struct {
+	OSImage                 string
+	KernelVersion           string
+	KubeletVersion          string
+	ContainerRuntime        string
+	ActiveLSM               string
+	KernelHeaderPresent     bool
+	HostSecurity            bool
+	ContainerSecurity       bool
+	ContainerDefaultPosture tp.DefaultPosture
+	HostDefaultPosture      tp.DefaultPosture
+	HostVisibility          string
+}
+
+// Status data
+type Status struct {
+	Desired   string `json:"desired"`
+	Ready     string `json:"ready"`
+	Available string `json:"available"`
+}
+
+// KubeArmorPodSpec structure definition
+type KubeArmorPodSpec struct {
+	Running       string `json:"running"`
+	Image_Version string `json:"image_version"`
+}
+
+// NamespaceData structure definition
+type NamespaceData struct {
+	NsPostureString    string            `json:"-"`
+	NsVisibilityString string            `json:"-"`
+	NsDefaultPosture   tp.DefaultPosture `json:"default_posture"`
+	NsVisibility       Visibility        `json:"visibility"`
+	NsPodList          []PodInfo         `json:"pod_list"`
+}
+
+// Visibility data structure definition
+type Visibility struct {
+	File         bool `json:"file"`
+	Capabilities bool `json:"capabilities"`
+	Process      bool `json:"process"`
+	Network      bool `json:"network"`
+}
+
+// PodInfo structure definition
+type PodInfo struct {
+	PodName string `json:"pod_name"`
+	Policy  string `json:"policy"`
+}


### PR DESCRIPTION
**Purpose of PR?**:

Fixes #302  #298 

**Does this PR introduce a breaking change?**
No

**Description** 
We can get the `karmor probe`  data in json format using `karmor probe -f json` .

```json 

  "Probe Data": {
    "ArmoredPods": {
      "Namespaces": {
        "accuknox-agents": {
          "default_posture": {
            "file": "audit",
            "network": "audit",
            "capabilties": "audit"
          },
          "visibility": {
            "file": true,
            "capabilities": true,
            "process": true,
            "network": true
          },
          "pod_list": [
            {
              "pod_name": "discovery-engine-5b7f44795d-fvzgr",
              "policy": ""
            }
          ]
        },
        "cert-manager": {
          "default_posture": {
            "file": "audit",
            "network": "audit",
            "capabilties": "audit"
          },
          "visibility": {
            "file": true,
            "capabilities": true,
            "process": true,
            "network": true
          },
          "pod_list": [
            {
              "pod_name": "cert-manager-6868fddcb4-zm7sk",
              "policy": ""
            },
            {
              "pod_name": "cert-manager-cainjector-ccb9bc698-bmv9n",
              "policy": ""
            },
            {
              "pod_name": "cert-manager-webhook-8bc4cf7d8-7j8c7",
              "policy": ""
            }
          ]
        },
        "default": {
          "default_posture": {
            "file": "audit",
            "network": "audit",
            "capabilties": "audit"
          },
          "visibility": {
            "file": true,
            "capabilities": true,
            "process": true,
            "network": true
          },
          "pod_list": [
            {
              "pod_name": "nginx-8f458dc5b-8rk76",
              "policy": ""
            }
          ]
        },
        "external-secrets": {
          "default_posture": {
            "file": "audit",
            "network": "audit",
            "capabilties": "audit"
          },
          "visibility": {
            "file": false,
            "capabilities": false,
            "process": true,
            "network": false
          },
          "pod_list": [
            {
              "pod_name": "external-secrets-588748d7c8-l94hz",
              "policy": ""
            },
            {
              "pod_name": "external-secrets-cert-controller-b5b7bc794-rd89b",
              "policy": ""
            },
            {
              "pod_name": "external-secrets-webhook-5f6c98bbd9-bwkzq",
              "policy": ""
            }
          ]
        }
      }
    },
    "Containers": {
      "kubearmor-annotation-manager-85857fc8d7-tj6wl": {
        "running": "2",
        "image_version": "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
      },
      "kubearmor-controller-manager-7d84b6c4d9-6b9gn": {
        "running": "2",
        "image_version": "ttl.sh/dsp-controller:24h"
      },
      "kubearmor-host-policy-manager-7b9c9db44-dc89c": {
        "running": "2",
        "image_version": "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
      },
      "kubearmor-policy-manager-8569dd9d6f-gd76j": {
        "running": "2",
        "image_version": "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
      },
      "kubearmor-relay-64c6fff875-crbpp": {
        "running": "1",
        "image_version": "kubearmor/kubearmor-relay-server:latest"
      },
      "kubearmor-thlcr": {
        "running": "1",
        "image_version": "kubearmor/kubearmor:stable"
      },
      "kubearmor-wsmzf": {
        "running": "1",
        "image_version": "kubearmor/kubearmor:stable"
      }
    },
    "DaemonsetStatus": {
      "desired": "2",
      "ready": "2",
      "available": "2"
    },
    "Deployments": {
      "kubearmor-annotation-manager": {
        "desired": "1",
        "ready": "1",
        "available": "1"
      },
      "kubearmor-controller-manager": {
        "desired": "1",
        "ready": "1",
        "available": "1"
      },
      "kubearmor-host-policy-manager": {
        "desired": "1",
        "ready": "1",
        "available": "1"
      },
      "kubearmor-policy-manager": {
        "desired": "1",
        "ready": "1",
        "available": "1"
      },
      "kubearmor-relay": {
        "desired": "1",
        "ready": "1",
        "available": "1"
      }
    },
    "Nodes": {
      "Node1": {
        "OSImage": "Ubuntu 18.04.6 LTS",
        "KernelVersion": "5.4.0-1104-azure",
        "KubeletVersion": "v1.24.10",
        "ContainerRuntime": "containerd://1.6.18+azure-1",
        "ActiveLSM": "AppArmor",
        "KernelHeaderPresent": true,
        "HostSecurity": false,
        "ContainerSecurity": true,
        "ContainerDefaultPosture": {
          "file": "audit",
          "network": "audit",
          "capabilties": "audit"
        },
        "HostDefaultPosture": {
          "file": "audit",
          "network": "audit",
          "capabilties": "audit"
        },
        "HostVisibility": "none"
      },
      "Node2": {
        "OSImage": "Ubuntu 18.04.6 LTS",
        "KernelVersion": "5.4.0-1104-azure",
        "KubeletVersion": "v1.24.10",
        "ContainerRuntime": "containerd://1.6.18+azure-1",
        "ActiveLSM": "AppArmor",
        "KernelHeaderPresent": true,
        "HostSecurity": false,
        "ContainerSecurity": true,
        "ContainerDefaultPosture": {
          "file": "audit",
          "network": "audit",
          "capabilties": "audit"
        },
        "HostDefaultPosture": {
          "file": "audit",
          "network": "audit",
          "capabilties": "audit"
        },
        "HostVisibility": "none"
      }
    }
  }

```
output for  `karmor probe -f text`
```Found KubeArmor running in Kubernetes

Daemonset :
 	kubearmor 	Desired: 1	Ready: 1	Available: 1	
Deployments : 
 	kubearmor-relay     	Desired: 1	Ready: 1	Available: 1	
 	kubearmor-controller	Desired: 1	Ready: 1	Available: 1	
Containers : 
 	kubearmor-relay-5656cc5bf7-htzft    	Running: 1	Image Version: kubearmor/kubearmor-relay-server:latest  	
 	kubearmor-controller-5c955748d-kb6xs	Running: 2	Image Version: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0	
 	kubearmor-74t8s                     	Running: 1	Image Version: kubearmor/kubearmor:stable               	
Node 1 : 
 	OS Image:                 	Ubuntu 22.04.1 LTS	
 	Kernel Version:           	5.19.0-45-generic 	
 	Kubelet Version:          	v1.23.9+k3s1      	
 	Container Runtime:        	docker://24.0.2   	
 	Active LSM:               	AppArmor          	
 	Host Security:            	false             	
 	Container Security:       	true              	
 	Container Default Posture:	audit(File)       	audit(Capabilities)	audit(Network)	
 	Host Default Posture:     	audit(File)       	audit(Capabilities)	audit(Network)	
 	Host Visibility:          	none              	
Armored Up pods : 
+-------------+--------------------------------+------------+--------------------------------------+--------+
|  NAMESPACE  |        DEFAULT POSTURE         | VISIBILITY |                 NAME                 | POLICY |
+-------------+--------------------------------+------------+--------------------------------------+--------+
| multiubuntu |  file (block), capabilities    | file       | ubuntu-3-deployment-59445d6fb7-ns7ql |        |
|             | (audit), Network (audit)       |            |                                      |        |
+             +                                +            +--------------------------------------+--------+
|             |                                |            | ubuntu-5-deployment-6c6b5fccbb-wm98j |        |
|             |                                |            |                                      |        |
+             +                                +            +--------------------------------------+--------+
|             |                                |            | ubuntu-4-deployment-868dd7ddb-rvc7j  |        |
|             |                                |            |                                      |        |
+             +                                +            +--------------------------------------+--------+
|             |                                |            | ubuntu-1-deployment-5bd4dff469-5snlr |        |
|             |                                |            |                                      |        |
+             +                                +            +--------------------------------------+--------+
|             |                                |            | ubuntu-2-deployment-55c894ddb5-6bmtd |        |
|             |                                |            |                                      |        |
+-------------+--------------------------------+------------+--------------------------------------+--------+
```