### PR TITLE
Removed DE dependency from recommend

### DIFF
--- a/recommend/imageHandler.go
+++ b/recommend/imageHandler.go
@@ -529,7 +529,7 @@ func imageHandler(namespace, deployment string, labels LabelMap, imageName strin
 		}
 		err := initClientConnection(c)
 		if err != nil {
-			log.WithError(err).Error("failed to initialize DE client connection. Won't recommend admission controller policies.")
+			log.WithError(err).Info("failed to initialize DE client connection. Won't recommend admission controller policies.")
 			//return err
 		} else {
 			err = recommendAdmissionControllerPolicies(img)

--- a/recommend/imageHandler.go
+++ b/recommend/imageHandler.go
@@ -529,13 +529,14 @@ func imageHandler(namespace, deployment string, labels LabelMap, imageName strin
 		}
 		err := initClientConnection(c)
 		if err != nil {
-			log.WithError(err).Error("failed to initialize client connection.")
-			return err
-		}
-		err = recommendAdmissionControllerPolicies(img)
-		if err != nil {
-			log.WithError(err).Error("failed to recommend admission controller policies.")
-			return err
+			log.WithError(err).Error("failed to initialize DE client connection. Won't recommend admission controller policies.")
+			//return err
+		} else {
+			err = recommendAdmissionControllerPolicies(img)
+			if err != nil {
+				log.WithError(err).Error("failed to recommend admission controller policies.")
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Related to issue https://github.com/kubearmor/kubearmor-client/issues/329

Due to the new admission controller implementation, the entire recommend command was dependent on the DE due to a small error management. I have fixed that. Now recommend will run even if DE is not running, it just wont display any policies that require summary data from DE if discovery engine is not in the cluster.

![image](https://github.com/kubearmor/kubearmor-client/assets/23097199/bac08adb-4fda-42ee-b16a-8793f2c1f4e5)
