### PR TITLE
feat(install): wait for KubeArmor to create probe file before probing

### DIFF
--- a/probe/probe.go
+++ b/probe/probe.go
@@ -489,9 +489,9 @@ func readDataFromKubeArmor(c *k8s.Client, o Options, nodeName string) (KubeArmor
 		VersionedParams(&corev1.PodExecOptions{
 			Container: pods.Items[0].Spec.Containers[0].Name,
 			Command:   cmdArr,
-			Stdin:     true,
+			Stdin:     false,
 			Stdout:    true,
-			Stderr:    true,
+			Stderr:    false,
 			TTY:       false,
 		}, scheme.ParameterCodec)
 	exec, err := remotecommand.NewSPDYExecutor(c.Config, "POST", req.URL())
@@ -501,9 +501,7 @@ func readDataFromKubeArmor(c *k8s.Client, o Options, nodeName string) (KubeArmor
 	go func() {
 		defer outStream.Close()
 		err = exec.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
-			Stdin:  os.Stdin,
 			Stdout: outStream,
-			Stderr: os.Stderr,
 			Tty:    false,
 		})
 	}()


### PR DESCRIPTION
KubeArmor takes some time to initialise Monitor and Enforcer and probe information is only generated when all the sub routines are active. 

So now, we keep trying to probe information from KubeArmor till we get info out or context times out.

We also have a slow animation while waiting so user know something is in process.
![image](https://github.com/kubearmor/kubearmor-client/assets/47106543/d1e96393-6b00-42af-935b-d7740c0f823a)
