### PR TITLE
fix(bug) : Empty column if namespace visibility is not annotated

### DIFF
--- a/cmd/probe.go
+++ b/cmd/probe.go
@@ -22,10 +22,9 @@ and what KubeArmor features will be supported e.g: observability, enforcement, e
 If KubeArmor is running, It probes which environment KubeArmor is running on (e.g: systemd mode, kubernetes etc.), 
 the supported KubeArmor features in the environment, the pods being handled by KubeArmor and the policies running on each of these pods`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := probe.PrintProbeResult(client, probeInstallOptions); err != nil {
-			return err
-		}
-		return nil
+
+		err := probe.PrintProbeResult(client, probeInstallOptions)
+		return err
 
 	},
 }
@@ -35,4 +34,5 @@ func init() {
 	probeCmd.Flags().StringVarP(&probeInstallOptions.Namespace, "namespace", "n", "kube-system", "Namespace for resources")
 	probeCmd.Flags().BoolVar(&probeInstallOptions.Full, "full", false, `If KubeArmor is not running, it deploys a daemonset to have access to more
 information on KubeArmor support in the environment and deletes daemonset after probing`)
+	probeCmd.Flags().StringVarP(&probeInstallOptions.Output, "format", "f", "text", " Format: json or text ")
 }

--- a/install/install.go
+++ b/install/install.go
@@ -152,7 +152,7 @@ func checkPods(c *k8s.Client, o Options) {
 			fmt.Print("⚠️\tFailed verifying KubeArmor functionality ...")
 			return
 		}
-		probeData, err := probe.ProbeRunningKubeArmorNodes(c, probe.Options{
+		probeData, _, err := probe.ProbeRunningKubeArmorNodes(c, probe.Options{
 			Namespace: o.Namespace,
 		})
 		if err != nil || len(probeData) == 0 {

--- a/probe/print.go
+++ b/probe/print.go
@@ -1,0 +1,116 @@
+package probe
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/fatih/color"
+	"github.com/olekukonko/tablewriter"
+)
+
+func renderOutputInTableWithNoBorders(data [][]string) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+	table.AppendBulk(data) // Add Bulk Data
+	table.Render()
+}
+
+// printDaemonsetData function
+func printDaemonsetData(daemonsetStatus *Status) {
+	var data [][]string
+
+	color.Green("\nFound KubeArmor running in Kubernetes\n\n")
+	_, err := boldWhite.Printf("Daemonset :\n")
+	if err != nil {
+		color.Red(" Error while printing")
+	}
+	data = append(data, []string{" ", "kubearmor ", "Desired: " + daemonsetStatus.Desired, "Ready: " + daemonsetStatus.Ready, "Available: " + daemonsetStatus.Available})
+	renderOutputInTableWithNoBorders(data)
+}
+
+// printKubeArmorDeployments function
+func printKubearmorDeployments(deploymentData map[string]*Status) {
+
+	_, err := boldWhite.Printf("Deployments : \n")
+	if err != nil {
+		color.Red(" Error while printing")
+	}
+	var data [][]string
+	for depName, depStatus := range deploymentData {
+		data = append(data, []string{" ", depName, "Desired: " + depStatus.Desired, "Ready: " + depStatus.Ready, "Available: " + depStatus.Available})
+	}
+
+	renderOutputInTableWithNoBorders(data)
+}
+
+// printKubeArmorContainers function
+func printKubeArmorContainers(containerData map[string]*KubeArmorPodSpec) {
+	var data [][]string
+
+	_, err := boldWhite.Printf("Containers : \n")
+	if err != nil {
+		color.Red(" Error while printing")
+	}
+	for name, spec := range containerData {
+
+		data = append(data, []string{" ", name, "Running: " + spec.Running, "Image Version: " + spec.Image_Version})
+	}
+	renderOutputInTableWithNoBorders(data)
+}
+
+// printKubeArmorprobe function
+func printKubeArmorprobe(probeData []KubeArmorProbeData) {
+
+	for i, pd := range probeData {
+		_, err := boldWhite.Printf("Node %d : \n", i+1)
+		if err != nil {
+			color.Red(" Error")
+		}
+		printKubeArmorProbeOutput(pd)
+	}
+
+}
+
+// printKubeArmorProbeOutput function
+func printKubeArmorProbeOutput(kd KubeArmorProbeData) {
+	var data [][]string
+	data = append(data, []string{" ", "OS Image:", green(kd.OSImage)})
+	data = append(data, []string{" ", "Kernel Version:", green(kd.KernelVersion)})
+	data = append(data, []string{" ", "Kubelet Version:", green(kd.KubeletVersion)})
+	data = append(data, []string{" ", "Container Runtime:", green(kd.ContainerRuntime)})
+	data = append(data, []string{" ", "Active LSM:", green(kd.ActiveLSM)})
+	data = append(data, []string{" ", "Host Security:", green(strconv.FormatBool(kd.HostSecurity))})
+	data = append(data, []string{" ", "Container Security:", green(strconv.FormatBool(kd.ContainerSecurity))})
+	data = append(data, []string{" ", "Container Default Posture:", green(kd.ContainerDefaultPosture.FileAction) + itwhite("(File)"), green(kd.ContainerDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.ContainerDefaultPosture.NetworkAction) + itwhite("(Network)")})
+	data = append(data, []string{" ", "Host Default Posture:", green(kd.HostDefaultPosture.FileAction) + itwhite("(File)"), green(kd.HostDefaultPosture.CapabilitiesAction) + itwhite("(Capabilities)"), green(kd.HostDefaultPosture.NetworkAction) + itwhite("(Network)")})
+	data = append(data, []string{" ", "Host Visibility:", green(kd.HostVisibility)})
+	renderOutputInTableWithNoBorders(data)
+}
+
+// printAnnotatedPods function
+func printAnnotatedPods(podData [][]string) {
+
+	_, err := boldWhite.Printf("Armored Up pods : \n")
+	if err != nil {
+		color.Red(" Error printing bold text")
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"NAMESPACE", "DEFAULT POSTURE", "VISIBILITY", "NAME", "POLICY"})
+	for _, v := range podData {
+		table.Append(v)
+	}
+	table.SetRowLine(true)
+	table.SetAutoMergeCellsByColumnIndex([]int{0, 1, 2})
+	table.Render()
+}

--- a/probe/types.go
+++ b/probe/types.go
@@ -1,0 +1,63 @@
+package probe
+
+import (
+	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
+)
+
+// Options provides probe daemonset options install
+type Options struct {
+	Namespace string
+	Full      bool
+	Output    string
+}
+
+// KubeArmorProbeData structure definition
+type KubeArmorProbeData struct {
+	OSImage                 string
+	KernelVersion           string
+	KubeletVersion          string
+	ContainerRuntime        string
+	ActiveLSM               string
+	KernelHeaderPresent     bool
+	HostSecurity            bool
+	ContainerSecurity       bool
+	ContainerDefaultPosture tp.DefaultPosture
+	HostDefaultPosture      tp.DefaultPosture
+	HostVisibility          string
+}
+
+// Status data
+type Status struct {
+	Desired   string `json:"desired"`
+	Ready     string `json:"ready"`
+	Available string `json:"available"`
+}
+
+// KubeArmorPodSpec structure definition
+type KubeArmorPodSpec struct {
+	Running       string `json:"running"`
+	Image_Version string `json:"image_version"`
+}
+
+// NamespaceData structure definition
+type NamespaceData struct {
+	NsPostureString    string            `json:"-"`
+	NsVisibilityString string            `json:"-"`
+	NsDefaultPosture   tp.DefaultPosture `json:"default_posture"`
+	NsVisibility       Visibility        `json:"visibility"`
+	NsPodList          []PodInfo         `json:"pod_list"`
+}
+
+// Visibility data structure definition
+type Visibility struct {
+	File         bool `json:"file"`
+	Capabilities bool `json:"capabilities"`
+	Process      bool `json:"process"`
+	Network      bool `json:"network"`
+}
+
+// PodInfo structure definition
+type PodInfo struct {
+	PodName string `json:"pod_name"`
+	Policy  string `json:"policy"`
+}


### PR DESCRIPTION
Currently karmor probe displays empty visibility column if the namespace visibility is not annotated, with this PR we will be setting the visibility same as host visibility.
```ound KubeArmor running in Kubernetes

Daemonset :
 	kubearmor 	Desired: 2	Ready: 2	Available: 2	
Deployments : 
 	kubearmor-relay     	Desired: 1	Ready: 1	Available: 1	
 	kubearmor-controller	Desired: 1	Ready: 1	Available: 1	
Containers : 
 	kubearmor-controller-95fd5f547-pmwxt	Running: 2	Image Version: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0	
 	kubearmor-qt68h                     	Running: 1	Image Version: kubearmor/kubearmor:stable               	
 	kubearmor-relay-6fddb8865b-rfknd    	Running: 1	Image Version: kubearmor/kubearmor-relay-server:latest  	
 	kubearmor-zrtgz                     	Running: 1	Image Version: kubearmor/kubearmor:stable               	
Node 1 : 
 	OS Image:                 	Ubuntu 22.04.2 LTS        	
 	Kernel Version:           	5.15.0-1040-azure         	
 	Kubelet Version:          	v1.25.6                   	
 	Container Runtime:        	containerd://1.7.1+azure-1	
 	Active LSM:               	AppArmor                  	
 	Host Security:            	false                     	
 	Container Security:       	true                      	
 	Container Default Posture:	audit(File)               	audit(Capabilities)	audit(Network)	
 	Host Default Posture:     	audit(File)               	audit(Capabilities)	audit(Network)	
 	Host Visibility:          	none                      	
Node 2 : 
 	OS Image:                 	Ubuntu 22.04.2 LTS        	
 	Kernel Version:           	5.15.0-1040-azure         	
 	Kubelet Version:          	v1.25.6                   	
 	Container Runtime:        	containerd://1.7.1+azure-1	
 	Active LSM:               	AppArmor                  	
 	Host Security:            	false                     	
 	Container Security:       	true                      	
 	Container Default Posture:	audit(File)               	audit(Capabilities)	audit(Network)	
 	Host Default Posture:     	audit(File)               	audit(Capabilities)	audit(Network)	
 	Host Visibility:          	none                      	
Armored Up pods : 
+-----------+--------------------------------+------------+---------------------------------------+--------+
| NAMESPACE |        DEFAULT POSTURE         | VISIBILITY |                 NAME                  | POLICY |
+-----------+--------------------------------+------------+---------------------------------------+--------+
| default   | File(audit),                   | none       | vault-agent-injector-564cb95bdb-kvjpb |        |
|           | Capabilities(audit), Network   |            |                                       |        |
|           | (audit)                        |            |                                       |        |
+-----------+--------------------------------+------------+---------------------------------------+--------+
```
