### PR TITLE
fix(bug): empty column for visibility in karmor probe

### DIFF
--- a/probe/probe.go
+++ b/probe/probe.go
@@ -525,6 +525,7 @@ func getPostureData(probeData []KubeArmorProbeData) map[string]string {
 		postureData["filePosture"] = probeData[0].ContainerDefaultPosture.FileAction
 		postureData["capabilitiesPosture"] = probeData[0].ContainerDefaultPosture.CapabilitiesAction
 		postureData["networkPosture"] = probeData[0].ContainerDefaultPosture.NetworkAction
+		postureData["visibility"] = probeData[0].HostVisibility
 	}
 
 	return postureData
@@ -590,6 +591,7 @@ func getNsSecurityPostureAndVisibility(c *k8s.Client, postureData map[string]str
 		filePosture := postureData["filePosture"]
 		capabilityPosture := postureData["capabilitiesPosture"]
 		networkPosture := postureData["networkPosture"]
+		visibility := postureData["visibility"]
 
 		if len(ns.Annotations["kubearmor-file-posture"]) > 0 {
 			filePosture = ns.Annotations["kubearmor-file-posture"]
@@ -603,14 +605,18 @@ func getNsSecurityPostureAndVisibility(c *k8s.Client, postureData map[string]str
 			networkPosture = ns.Annotations["kubearmor-network-posture"]
 		}
 
+		if len(ns.Annotations["kubearmor-visibility"]) > 0 {
+			visibility = ns.Annotations["kubearmor-visibility"]
+		}
+
 		mp[ns.Name] = &NamespaceData{
 			NsDefaultPosture:   tp.DefaultPosture{FileAction: filePosture, CapabilitiesAction: capabilityPosture, NetworkAction: networkPosture},
-			NsVisibilityString: ns.Annotations["kubearmor-visibility"],
+			NsVisibilityString: visibility,
 			NsVisibility: Visibility{
-				Process:      strings.Contains(ns.Annotations["kubearmor-visibility"], "process"),
-				File:         strings.Contains(ns.Annotations["kubearmor-visibility"], "file"),
-				Network:      strings.Contains(ns.Annotations["kubearmor-visibility"], "network"),
-				Capabilities: strings.Contains(ns.Annotations["kubearmor-visibility"], "capabilities"),
+				Process:      strings.Contains(visibility, "process"),
+				File:         strings.Contains(visibility, "file"),
+				Network:      strings.Contains(visibility, "network"),
+				Capabilities: strings.Contains(visibility, "capabilities"),
 			},
 			NsPostureString: "File(" + filePosture + "), Capabilities(" + capabilityPosture + "), Network (" + networkPosture + ")",
 		}


### PR DESCRIPTION
Currently karmor probe displays empty visibility column if the namespace visibility is not annotated, with this PR we will be setting the visibility same as host visibility.
```
Daemonset :
 	kubearmor 	Desired: 2	Ready: 2	Available: 2	
Deployments : 
 	kubearmor-controller	Desired: 1	Ready: 1	Available: 1	
 	kubearmor-relay     	Desired: 1	Ready: 1	Available: 1	
Containers : 
 	kubearmor-controller-95fd5f547-pmwxt	Running: 2	Image Version: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0	
 	kubearmor-qt68h                     	Running: 1	Image Version: kubearmor/kubearmor:stable               	
 	kubearmor-relay-6fddb8865b-rfknd    	Running: 1	Image Version: kubearmor/kubearmor-relay-server:latest  	
 	kubearmor-zrtgz                     	Running: 1	Image Version: kubearmor/kubearmor:stable               	
Node 1 : 
 	OS Image:                 	Ubuntu 22.04.2 LTS        	
 	Kernel Version:           	5.15.0-1040-azure         	
 	Kubelet Version:          	v1.25.6                   	
 	Container Runtime:        	containerd://1.7.1+azure-1	
 	Active LSM:               	AppArmor                  	
 	Host Security:            	false                     	
 	Container Security:       	true                      	
 	Container Default Posture:	audit(File)               	audit(Capabilities)	audit(Network)	
 	Host Default Posture:     	audit(File)               	audit(Capabilities)	audit(Network)	
 	Host Visibility:          	none                      	
Node 2 : 
 	OS Image:                 	Ubuntu 22.04.2 LTS        	
 	Kernel Version:           	5.15.0-1040-azure         	
 	Kubelet Version:          	v1.25.6                   	
 	Container Runtime:        	containerd://1.7.1+azure-1	
 	Active LSM:               	AppArmor                  	
 	Host Security:            	false                     	
 	Container Security:       	true                      	
 	Container Default Posture:	audit(File)               	audit(Capabilities)	audit(Network)	
 	Host Default Posture:     	audit(File)               	audit(Capabilities)	audit(Network)	
 	Host Visibility:          	none                      	
Armored Up pods : 
+-----------+--------------------------------+------------+---------------------------------------+--------+
| NAMESPACE |        DEFAULT POSTURE         | VISIBILITY |                 NAME                  | POLICY |
+-----------+--------------------------------+------------+---------------------------------------+--------+
| default   | File(audit),                   | none       | vault-agent-injector-564cb95bdb-kvjpb |        |
|           | Capabilities(audit), Network   |            |                                       |        |
|           | (audit)                        |            |                                       |        |
+-----------+--------------------------------+------------+---------------------------------------+--------+
```
