### PR TITLE
optimize: make the summary json format more formal

### DIFF
--- a/summary/summary.go
+++ b/summary/summary.go
@@ -40,8 +40,8 @@ type Options struct {
 }
 
 // GetSummary on pods
-func GetSummary(c *k8s.Client, o Options) ([]string, error) {
-	var str []string
+func GetSummary(c *k8s.Client, o Options) ([]*opb.Response, error) {
+	var jsonObs []*opb.Response
 	gRPC := ""
 	targetSvc := "discovery-engine"
 
@@ -87,12 +87,9 @@ func GetSummary(c *k8s.Client, o Options) ([]string, error) {
 			DisplaySummaryOutput(sumResp, o.RevDNSLookup, o.Type)
 		}
 
-		sumstr := ""
 		if o.Output == "json" {
-			arr, _ := json.MarshalIndent(sumResp, "", "    ")
-			sumstr = fmt.Sprintf("%s\n", string(arr))
-			str = append(str, sumstr)
-			return str, nil
+			jsonObs = append(jsonObs, sumResp)
+			return jsonObs, nil
 		}
 
 	} else {
@@ -115,31 +112,29 @@ func GetSummary(c *k8s.Client, o Options) ([]string, error) {
 				DisplaySummaryOutput(sumResp, o.RevDNSLookup, o.Type)
 			}
 
-			sumstr := ""
 			if o.Output == "json" {
-				arr, _ := json.MarshalIndent(sumResp, "", "    ")
-				sumstr = fmt.Sprintf("%s\n", string(arr))
-				str = append(str, sumstr)
+				jsonObs = append(jsonObs, sumResp)
 			}
 		}
 		if o.Output == "json" {
-			return str, nil
+			return jsonObs, nil
 		}
 	}
-	return str, nil
+	return jsonObs, nil
 }
 
 // Summary - printing the summary output
 func Summary(c *k8s.Client, o Options) error {
-
 	summary, err := GetSummary(c, o)
 	if err != nil {
 		return err
 	}
-	for _, sum := range summary {
-		if o.Output == "json" {
-			fmt.Printf("%s", sum)
+	if o.Output == "json" {
+		summaryJson, err := json.MarshalIndent(summary, "", "    ")
+		if err != nil {
+			return err
 		}
+		fmt.Printf("%s", string(summaryJson))
 	}
 	return nil
 }


### PR DESCRIPTION
During the development of the visualization section for Kubeararmor -action, I need to parse the json file that is currently being output in an irregular format.
fixed json data will like this way:
```json
[{
    "DeploymentName": "mysql-5df4cd65d5-v66vz",
    "PodName": "default",
    "ClusterName": "wordpress-mysql",
    "Label": "k8s_POD_mysql-5df4cd65d5-v66vz_wordpress-mysql_3bba6413-e8e9-498a-a354-3db860c6eb23_0",
    "ContainerName": "\n\t/bin/bash\u0012\u0010/usr/sbin/mysqld\u001a\u00013\"\u001cMon Jul 17 12:05:14 UTC 2023*\u0005Allow",
    "ProcessData": [
        {
            "Source": "/usr/local/bin/docker-entrypoint.sh",
            "Destination": "/dev/tty",
            "Count": "1",
            "UpdatedTime": "Mon Jul 17 12:05:06 UTC 2023",
            "Status": "Allow"
        },
        {
            "Source": "/bin/bash",
            "Destination": "/",
            "Count": "1",
            "UpdatedTime": "Mon Jul 17 12:05:04 UTC 2023",
            "Status": "Allow"
        },
........
},
{
......
}]
```
Fixes: #327 