### PR TITLE
stop karmor logs if the Watch* fails

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -17,10 +17,7 @@ var logCmd = &cobra.Command{
 	Long:  `Observe Logs from KubeArmor`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.StopChan = make(chan struct{})
-		if err := log.StartObserver(client, logOptions); err != nil {
-			return err
-		}
-		return nil
+		return log.StartObserver(client, logOptions)
 	},
 }
 


### PR DESCRIPTION
Exit the `karmor logs` if connectivity/port-forwarding breaks because of connection issues or anything else.