### PR TITLE
Changed PodName to ContainerName

### DIFF
--- a/profile/Client/profileClient.go
+++ b/profile/Client/profileClient.go
@@ -104,7 +104,7 @@ func generateColumns(Operation string) []table.Column {
 
 	Namespace := table.NewFlexColumn(ColumnNamespace, "Namespace", 2).WithStyle(ColumnStyle).WithFiltered(true)
 
-	PodName := table.NewFlexColumn(ColumnPodname, "Podname", 4).WithStyle(ColumnStyle).WithFiltered(true)
+	PodName := table.NewFlexColumn(ColumnPodname, "ContainerName", 4).WithStyle(ColumnStyle).WithFiltered(true)
 
 	ProcName := table.NewFlexColumn(ColumnProcessName, "ProcessName", 3).WithStyle(ColumnStyle).WithFiltered(true)
 


### PR DESCRIPTION
Previously karmor profile showed podname, but now we use ContainerName, so changed the heading of the column.