### PR TITLE
fix(improvements): Improve the usability of karmor probe by detailing…

### DIFF
--- a/probe/probe.go
+++ b/probe/probe.go
@@ -534,8 +534,9 @@ func getPostureData(probeData []KubeArmorProbeData) map[string]string {
 // sudo systemctl status kubearmor
 func isSystemdMode() bool {
 	cmd := exec.Command("systemctl", "status", "kubearmor")
-	_, err := cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
+		log.Println("systemctl status kubearmor cannot be executed:", string(out))
 		return false
 	}
 	color.Green("\nFound KubeArmor running in Systemd mode \n\n")


### PR DESCRIPTION
… error messages

When KubeArmor is running in `systemd mode`, the following error may occur when executing "karmor probe".

  ```
  > karmor probe
  probe.go:380: error when getting kubearmor daemonset Get "http://localhost:8080/apis/apps/v1/namespaces/kube-system/daemonsets/kubearmor": dial tcp 127.0.0.1:8080: connect: connection refused

  Didn't find KubeArmor in systemd or Kubernetes, probing for support for KubeArmor

  Host:
    Observability/Audit: Supported (Kernel Version 5.15.0)
    Enforcement: Full (Supported LSMs: lockdown,capability,landlock,yama,apparmor)
  To get full probe, a daemonset will be deployed in your cluster - This daemonset will be deleted after probing
  Use --full tag to get full probing
  ```

When "karmor probe" is executed, "systemctl status kubearmor" is executed internally, but the systemctl command may require sudo. In this case, without sudo, an error occurs.

In this commit, to make it easier to understand the root cause of such an error, error messages have been modified to be more detailed.