### PR TITLE
(feat) Ability export profile data

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -27,4 +27,5 @@ func init() {
 	profilecmd.Flags().StringVarP(&profileOptions.Namespace, "namespace", "n", "", "Filter using namespace")
 	profilecmd.Flags().StringVar(&profileOptions.Pod, "pod", "", "Filter using Pod name")
 	profilecmd.Flags().StringVarP(&profileOptions.Container, "container", "c", "", "name of the container ")
+	profilecmd.Flags().BoolVar(&profileOptions.Save, "save", false, "Save Profile data in json format")
 }

--- a/profile/Client/profileClient.go
+++ b/profile/Client/profileClient.go
@@ -8,6 +8,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/accuknox/auto-policy-discovery/src/common"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -18,9 +22,6 @@ import (
 	klog "github.com/kubearmor/kubearmor-client/log"
 	profile "github.com/kubearmor/kubearmor-client/profile"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"strings"
-	"time"
 )
 
 // Column keys
@@ -376,7 +377,7 @@ func AggregateSummary(inputMap map[Profile]*Frequency, Operation string) map[Pro
 	return outputMap
 }
 
-func convertToJson(Operation string, data []Profile) {
+func convertToJSON(Operation string, data []Profile) {
 	var jsonArray []string
 	jsonByte, _ := json.MarshalIndent(data, " ", "   ")
 	//unmarshalling here because it is marshalled two times for some reason
@@ -466,13 +467,13 @@ func generateRowsFromData(data []pb.Log, Operation string) []table.Row {
 
 	if o1.Save {
 		if Operation == "File" {
-			convertToJson("File", jsondata)
+			convertToJSON("File", jsondata)
 		} else if Operation == "Process" {
-			convertToJson("Process", jsondata)
+			convertToJSON("Process", jsondata)
 		} else if Operation == "Network" {
-			convertToJson("Network", jsondata)
+			convertToJSON("Network", jsondata)
 		} else if Operation == "Syscall" {
-			convertToJson("Syscall", jsondata)
+			convertToJSON("Syscall", jsondata)
 		}
 	}
 

--- a/profile/Client/profileClient.go
+++ b/profile/Client/profileClient.go
@@ -6,6 +6,7 @@ package profileclient
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"github.com/accuknox/auto-policy-discovery/src/common"
 	"github.com/charmbracelet/bubbles/help"
@@ -66,6 +67,7 @@ type Options struct {
 	Pod       string
 	GRPC      string
 	Container string
+	Save      bool
 }
 
 // Model for main Bubble Tea
@@ -300,12 +302,14 @@ func (m Model) View() string {
 
 // Profile Row Data to display
 type Profile struct {
-	Namespace     string
-	ContainerName string
-	Process       string
-	Resource      string
-	Result        string
-	Data          string
+	Namespace     string `json:"namespace"`
+	ContainerName string `json:"container-name"`
+	Process       string `json:"process"`
+	Resource      string `json:"resource"`
+	Result        string `json:"result"`
+	Data          string `json:"data"`
+	Count         int    `json:"count"`
+	Time          string `json:"time"`
 }
 
 // Frequency and Timestamp data for another map
@@ -372,8 +376,31 @@ func AggregateSummary(inputMap map[Profile]*Frequency, Operation string) map[Pro
 	return outputMap
 }
 
+func convertToJson(Operation string, data []Profile) {
+	var jsonArray []string
+	jsonByte, _ := json.MarshalIndent(data, " ", "   ")
+	//unmarshalling here because it is marshalled two times for some reason
+	if err := json.Unmarshal(jsonByte, &jsonArray); err != nil {
+		fmt.Println("Error parsing JSON array:", err)
+	}
+	if len(jsonArray) > 0 {
+		filepath := "Profile_Summary/"
+		err := os.MkdirAll(filepath, os.ModePerm)
+		err = os.WriteFile(filepath+Operation+".json", []byte(jsonArray[0]), 0600)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (p Profile) MarshalText() (text []byte, err error) {
+	type x Profile
+	return json.Marshal(x(p))
+}
+
 func generateRowsFromData(data []pb.Log, Operation string) []table.Row {
 	var s SomeData
+	var jsondata []Profile
 	m := make(map[Profile]int)
 	w := make(map[Profile]*Frequency)
 	for _, entry := range data {
@@ -425,8 +452,30 @@ func generateRowsFromData(data []pb.Log, Operation string) []table.Row {
 			ColumnCount:         frequency.freq,
 			ColumnTimestamp:     frequency.time,
 		})
+		jsondata = append(jsondata, Profile{
+			Namespace:     r.Namespace,
+			ContainerName: r.ContainerName,
+			Process:       r.Process,
+			Resource:      r.Resource,
+			Result:        r.Result,
+			Count:         frequency.freq,
+			Time:          frequency.time,
+		})
 		s.rows = append(s.rows, row)
 	}
+
+	if o1.Save {
+		if Operation == "File" {
+			convertToJson("File", jsondata)
+		} else if Operation == "Process" {
+			convertToJson("Process", jsondata)
+		} else if Operation == "Network" {
+			convertToJson("Network", jsondata)
+		} else if Operation == "Syscall" {
+			convertToJson("Syscall", jsondata)
+		}
+	}
+
 	return s.rows
 }
 
@@ -437,6 +486,7 @@ func Start(o Options) {
 		Pod:       o.Pod,
 		GRPC:      o.GRPC,
 		Container: o.Container,
+		Save:      o.Save,
 	}
 	p := tea.NewProgram(NewModel(), tea.WithAltScreen())
 	go func() {


### PR DESCRIPTION
New Feature added for profile! Now we can use the flag `karmor profile --save` to run profile, and as it runs, it sends the data to 4 separate json files for File, Process, Network and Summary respectively. All these files are stored in a common folder named `Profile_Summary`

![](https://user-images.githubusercontent.com/23097199/264808794-fd5b004e-450e-4282-9681-48077a63de5b.png)