### PR TITLE
fix for downloading policy-templete zip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 require (
 	github.com/accuknox/auto-policy-discovery/src v0.0.0-20230707054448-845969c25277
 	github.com/accuknox/auto-policy-discovery/src/protobuf v0.0.0-20230707054448-845969c25277
-	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/charmbracelet/bubbles v0.15.0
 	github.com/charmbracelet/bubbletea v0.23.2
 	github.com/charmbracelet/lipgloss v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,6 @@ github.com/bytecodealliance/wasmtime-go v0.27.0 h1:b/mvyw1YJSwF5zNxqLH9V24ENkZGA
 github.com/bytecodealliance/wasmtime-go v0.27.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/bytecodealliance/wasmtime-go/v3 v3.0.2 h1:3uZCA/BLTIu+DqCfguByNMJa2HVHpXvjfy0Dy7g6fuA=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/cavaliergopher/grab/v3 v3.0.1 h1:4z7TkBfmPjmLAAmkkAZNX/6QJ1nNFdv3SdIHXju0Fr4=
-github.com/cavaliergopher/grab/v3 v3.0.1/go.mod h1:1U/KNnD+Ft6JJiYoYBAimKH2XrYptb8Kl3DFGmsjpq4=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTxfm6M=

--- a/recommend/policyTemplates.go
+++ b/recommend/policyTemplates.go
@@ -97,17 +97,27 @@ func init() {
 }
 
 func downloadZip(url string, destination string) error {
-	resp, err := http.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
 	defer resp.Body.Close()
 
-	out, err := os.Create(destination)
+	out, err := os.Create(filepath.Clean(destination))
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		if err := out.Close(); err != nil {
+			kg.Warnf("Error closing os file %s\n", err)
+		}
+	}()
 
 	_, err = io.Copy(out, resp.Body)
 	if err != nil {

--- a/recommend/policyTemplates.go
+++ b/recommend/policyTemplates.go
@@ -7,13 +7,14 @@ import (
 	"archive/zip"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
 
-	"github.com/cavaliergopher/grab/v3"
 	"github.com/google/go-github/github"
 	kg "github.com/kubearmor/KubeArmor/KubeArmor/log"
 	pol "github.com/kubearmor/KubeArmor/pkg/KubeArmorController/api/security.kubearmor.com/v1"
@@ -95,6 +96,27 @@ func init() {
 	CurrentVersion = CurrentRelease()
 }
 
+func downloadZip(url string, destination string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(destination)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // DownloadAndUnzipRelease downloads the latest version of policy-templates
 func DownloadAndUnzipRelease() (string, error) {
 
@@ -106,20 +128,22 @@ func DownloadAndUnzipRelease() (string, error) {
 		return "", err
 	}
 	downloadURL := fmt.Sprintf("%s%s.zip", url, LatestVersion)
-	resp, err := grab.Get(getCachePath(), downloadURL)
+	zipPath := getCachePath() + ".zip"
+	err = downloadZip(downloadURL, zipPath)
 	if err != nil {
 		_ = removeData(getCachePath())
 		return "", err
 	}
-	err = unZip(resp.Filename, getCachePath())
+
+	err = unZip(zipPath, getCachePath())
 	if err != nil {
 		return "", err
 	}
-	err = removeData(resp.Filename)
+	err = removeData(zipPath)
 	if err != nil {
 		return "", err
 	}
-	_ = updatePolicyRules(strings.TrimSuffix(resp.Filename, ".zip"))
+	_ = updatePolicyRules(strings.TrimSuffix(zipPath, ".zip"))
 	CurrentVersion = CurrentRelease()
 	return LatestVersion, nil
 }

--- a/recommend/recommend.go
+++ b/recommend/recommend.go
@@ -106,11 +106,12 @@ func Recommend(c *k8s.Client, o Options) error {
 		}).Info("Found outdated version of policy-templates")
 		log.Info("Downloading latest version [", LatestVersion, "]")
 		if _, err := DownloadAndUnzipRelease(); err != nil {
-			return err
+			log.WithError(err).Error("could not download latest policy-templates version")
+		} else {
+			log.WithFields(log.Fields{
+				"Updated Version": LatestVersion,
+			}).Info("policy-templates updated")
 		}
-		log.WithFields(log.Fields{
-			"Updated Version": LatestVersion,
-		}).Info("policy-templates updated")
 	}
 
 	if err = createOutDir(o.OutDir); err != nil {


### PR DESCRIPTION
removed `grab` package dependency for downloading policy-template zip file.
`grab.Get` gives error `server returned 403 Forbidden`

using `net/http` package instead.
for ref - https://accuknox.slack.com/archives/C0229TD83RA/p1694106383879899