### PR TITLE
chore: use go toolchain 1.22.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: './go.mod'
 
-      - name: Install Cosign 
+      - name: Install Cosign
         uses: sigstore/cosign-installer@main
 
       -

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/kubearmor/kubearmor-client
 
 go 1.22
 
+toolchain go1.22.1
+
 replace (
 	github.com/etcd-io/bbolt => go.etcd.io/bbolt v1.3.6
 	github.com/optiopay/kafka => github.com/cilium/kafka v0.0.0-20180809090225-01ce283b732b

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:base"
   ],
   "constraints": {
-    "go": "1.21"
+    "go": "1.22"
   },
   "ignorePresets": [":prHourlyLimit2"],
 	"reviewers": ["team:maintainers"]


### PR DESCRIPTION
- Use `toolchain` directive to fix build failures in local.
- Update Go version in `renovate.json`
- Update Go version in releaser workflow.