### PR TITLE
Remove usage of sudo to install kubearmor-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Installation
 
 ```shell
-curl -sfL http://get.kubearmor.io/ | sudo sh -s -- -b /usr/local/bin
+`curl -sfL http://get.kubearmor.io/ | sh -s` 
 ```
 
 ### Installing From Source

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Installation
 
 ```shell
-`curl -sfL http://get.kubearmor.io/ | sh -s` 
+curl -sfL http://get.kubearmor.io/ | sh -s
 ```
 
 ### Installing From Source

--- a/install.sh
+++ b/install.sh
@@ -60,6 +60,8 @@ execute() {
     fi
     install "${srcdir}/${binexe}" "${BINDIR}/"
     log_info "installed ${BINDIR}/${binexe}"
+    log_info "karmor is installed in ${BINDIR}"
+    log_info "invoke ${BINDIR}/${binexe} or move karmor to your desired PATH"
   done
   rm -rf "${tmpdir}"
 }


### PR DESCRIPTION
Fix #415

Result
```bash
[lekaf974@~ ]$ curl -sfL http://get.kubearmor.io/ | sh -s -- -b "$HOME/.local/bin"
kubearmor/kubearmor-client info checking GitHub for latest tag
kubearmor/kubearmor-client info found version: 1.2.0 for v1.2.0/linux/amd64
kubearmor/kubearmor-client info installed /home/lekaf974/.local/bin/karmor
kubearmor/kubearmor-client info Add /home/lekaf974/.local/bin to your PATH
```