### PR TITLE
fixed stdout issue with log message

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -194,7 +194,7 @@ func StartObserver(c *k8s.Client, o Options) error {
 		if o.LogFilter == "all" || o.LogFilter == "policy" {
 			// watch alerts
 			go logClient.WatchAlerts(o)
-			fmt.Fprintln(os.Stdout, "Started to watch alerts")
+			fmt.Fprintln(os.Stderr, "Started to watch alerts")
 		}
 
 		if o.LogFilter == "all" || o.LogFilter == "system" {


### PR DESCRIPTION
We cannot use stdout with general messages since users redirect stdout to jq for beautifying json output.