### PR TITLE
Feat: added postUpdate option in Renovate for go tidy

### DIFF
--- a/recommend/report/html/header.html
+++ b/recommend/report/html/header.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.3/jquery.min.js">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js">
     </script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/js/bootstrap.min.js">
     </script>

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "constraints": {
     "go": "1.22"
   },
   "ignorePresets": [":prHourlyLimit2"],
-	"reviewers": ["team:maintainers"]
+	"reviewers": ["team:maintainers"],
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
Solves #428 

With this configuration, Renovate will automatically tidy your Go modules after each dependency update, ensuring that your go.sum file only contains necessary entries and is free from clutter associated with previous versions of your dependencies.