### PR TITLE
fix(uninstall):remove kubearmor annotations from kubernetes resources

### DIFF
--- a/install/customResource.go
+++ b/install/customResource.go
@@ -10,6 +10,8 @@ import (
 
 var kspName = "kubearmorpolicies.security.kubearmor.com"
 var hspName = "kubearmorhostpolicies.security.kubearmor.com"
+var cspName = "kubearmorclusterpolicies.security.kubearmor.com"
+var kocName = "kubearmorconfigs.operator.kubearmor.com"
 
 // CreateCustomResourceDefinition creates the CRD and add it into Kubernetes.
 func CreateCustomResourceDefinition(crdName string) apiextensions.CustomResourceDefinition {


### PR DESCRIPTION
fixes: #434 
1. If annotations are added at the owner level then we remove annotations from deployments, replicasets, statefulsets, daemonsets, job, cronjob.
2. If annotations are added at pod level then all the pods with annotations will be restarted(deleted).
3. Lists all the pods with `karmor uninstall` that will be restarted when `--force` flag will be used

- `karmor uninstall` output:

```
prateek@bot:~ $ ~/go/bin/karmor uninstall 
ℹ️   Resources not managed by helm/Global Resources are not cleaned up. Please use karmor uninstall --force if you want complete cleanup.
ℹ️   Following pods will get restarted with karmor uninstall --force: 
+-----+--------------------------+-----------+
| NO  |         POD NAME         | NAMESPACE |
+-----+--------------------------+-----------+
|   1 | example-replicaset-6k4z4 | default   |
|   2 | example-replicaset-6m7nq | default   |
|   3 | example-replicaset-727ds | default   |
|   4 | example-replicaset-7bskf | default   |
|   5 | example-replicaset-7ckcn | default   |
|   6 | example-replicaset-9npvb | default   |
|   7 | example-replicaset-bshxd | default   |
|   8 | example-replicaset-cjxm9 | default   |
|   9 | example-replicaset-fmc58 | default   |
|  10 | example-replicaset-ltwl7 | default   |
|  11 | example-replicaset-mpxvc | default   |
|  12 | example-replicaset-n4xsw | default   |
|  13 | example-replicaset-pn4mb | default   |
|  14 | example-replicaset-s774m | default   |
|  15 | example-replicaset-sqzm4 | default   |
|  16 | example-statefulset-0    | default   |
|  17 | example-statefulset-1    | default   |
|  18 | example-statefulset-10   | default   |
|  19 | example-statefulset-11   | default   |
|  20 | example-statefulset-12   | default   |
|  21 | example-statefulset-13   | default   |
|  22 | example-statefulset-14   | default   |
|  23 | example-statefulset-15   | default   |
|  24 | example-statefulset-16   | default   |
|  25 | example-statefulset-17   | default   |
|  26 | example-statefulset-18   | default   |
|  27 | example-statefulset-19   | default   |
|  28 | example-statefulset-2    | default   |
|  29 | example-statefulset-3    | default   |
|  30 | example-statefulset-4    | default   |
|  31 | example-statefulset-5    | default   |
|  32 | example-statefulset-6    | default   |
|  33 | example-statefulset-7    | default   |
|  34 | example-statefulset-8    | default   |
|  35 | example-statefulset-9    | default   |
+-----+--------------------------+-----------+
❌  KubeArmor resources removed
🔄  Checking if KubeArmor pods are stopped...
🔴  Done Checking; all services are stopped!             
⌚️  Termination Time: 5.294239144s 

```