### PR TITLE
fix(recommend): Ensure karmor recommend supports Docker v26 by updating static policies and refactor extractTar function

### DIFF
--- a/tests/recommend/res/out/ubuntu-18-04/file-integrity-monitoring.yaml
+++ b/tests/recommend/res/out/ubuntu-18-04/file-integrity-monitoring.yaml
@@ -1,32 +1,38 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
-  name: wordpress-wordpress-4-8-apache-system-monitoring-deny-write-under-bin-directory
-  namespace: wordpress-mysql
+  name: ubuntu-18-04-file-integrity-monitoring
 spec:
   action: Block
   file:
     matchDirectories:
-    - dir: /bin/
-      readOnly: true
-      recursive: true
     - dir: /sbin/
-      readOnly: true
-      recursive: true
-    - dir: /usr/sbin/
       readOnly: true
       recursive: true
     - dir: /usr/bin/
       readOnly: true
       recursive: true
-  message: Alert! An attempt to write below system binary directories denied.
+    - dir: /usr/lib/
+      readOnly: true
+      recursive: true
+    - dir: /usr/sbin/
+      readOnly: true
+      recursive: true
+    - dir: /bin/
+      readOnly: true
+      recursive: true
+    - dir: /boot/
+      readOnly: true
+      recursive: true
+  message: Detected and prevented compromise to File integrity
   selector:
     matchLabels:
-      app: wordpress
-  severity: 5
+      kubearmor.io/container.name: ubuntu
+  severity: 1
   tags:
   - NIST
   - NIST_800-53_AU-2
   - NIST_800-53_SI-4
   - MITRE
   - MITRE_T1036_masquerading
+  - MITRE_T1565_data_manipulation

--- a/tests/recommend/res/out/ubuntu-18-04/least-functionality-execute-package-management-process-in-container.yaml
+++ b/tests/recommend/res/out/ubuntu-18-04/least-functionality-execute-package-management-process-in-container.yaml
@@ -11,35 +11,17 @@ spec:
   severity: 5
   process:
     matchPaths:
-    - path: /usr/bin/apt
-    - path: /usr/bin/apt-get
-    - path: /bin/apt-get
-    - path: /sbin/apk
-    - path: /bin/apt
-    - path: /usr/bin/dpkg
-    - path: /bin/dpkg
-    - path: /usr/bin/gdebi
-    - path: /bin/gdebi
-    - path: /usr/bin/make
-    - path: /bin/make
-    - path: /usr/bin/yum
-    - path: /bin/yum
-    - path: /usr/bin/rpm
-    - path: /bin/rpm
-    - path: /usr/bin/dnf
-    - path: /bin/dnf
-    - path: /usr/bin/pacman
-    - path: /usr/sbin/pacman
-    - path: /bin/pacman
-    - path: /sbin/pacman
-    - path: /usr/bin/makepkg
-    - path: /usr/sbin/makepkg
-    - path: /bin/makepkg
-    - path: /sbin/makepkg
-    - path: /usr/bin/yaourt
-    - path: /usr/sbin/yaourt
-    - path: /bin/yaourt
-    - path: /sbin/yaourt
-    - path: /usr/bin/zypper
-    - path: /bin/zypper
+    - execname: apt
+    - execname: apt-get
+    - execname: apk
+    - execname: dpkg
+    - execname: gdebi
+    - execname: make
+    - execname: yum
+    - execname: rpm
+    - execname: dnf
+    - execname: pacman
+    - execname: makepkg
+    - execname: yaourt
+    - execname: zypper
   action: Block

--- a/tests/recommend/res/out/ubuntu-18-04/system-owner-discovery.yaml
+++ b/tests/recommend/res/out/ubuntu-18-04/system-owner-discovery.yaml
@@ -7,10 +7,10 @@ spec:
   message: System owner discovery command execution denied
   process:
     matchPaths:
-    - path: /usr/bin/who
-    - path: /usr/bin/w
-    - path: /usr/bin/id
-    - path: /usr/bin/whoami
+    - execname: who
+    - execname: w
+    - execname: id
+    - execname: whoami
   selector:
     matchLabels:
       kubearmor.io/container.name: ubuntu

--- a/tests/recommend/res/out/wordpress-mysql-wordpress/wordpress-4-8-apache-file-integrity-monitoring.yaml
+++ b/tests/recommend/res/out/wordpress-mysql-wordpress/wordpress-4-8-apache-file-integrity-monitoring.yaml
@@ -1,31 +1,39 @@
 apiVersion: security.kubearmor.com/v1
 kind: KubeArmorPolicy
 metadata:
-  name: ubuntu-18-04-system-monitoring-deny-write-under-bin-directory
+  name: wordpress-wordpress-4-8-apache-file-integrity-monitoring
+  namespace: wordpress-mysql
 spec:
   action: Block
   file:
     matchDirectories:
-    - dir: /bin/
-      readOnly: true
-      recursive: true
     - dir: /sbin/
-      readOnly: true
-      recursive: true
-    - dir: /usr/sbin/
       readOnly: true
       recursive: true
     - dir: /usr/bin/
       readOnly: true
       recursive: true
-  message: Alert! An attempt to write below system binary directories denied.
+    - dir: /usr/lib/
+      readOnly: true
+      recursive: true
+    - dir: /usr/sbin/
+      readOnly: true
+      recursive: true
+    - dir: /bin/
+      readOnly: true
+      recursive: true
+    - dir: /boot/
+      readOnly: true
+      recursive: true
+  message: Detected and prevented compromise to File integrity
   selector:
     matchLabels:
-      kubearmor.io/container.name: ubuntu
-  severity: 5
+      app: wordpress
+  severity: 1
   tags:
   - NIST
   - NIST_800-53_AU-2
   - NIST_800-53_SI-4
   - MITRE
   - MITRE_T1036_masquerading
+  - MITRE_T1565_data_manipulation

--- a/tests/recommend/res/out/wordpress-mysql-wordpress/wordpress-4-8-apache-least-functionality-execute-package-management-process-in-container.yaml
+++ b/tests/recommend/res/out/wordpress-mysql-wordpress/wordpress-4-8-apache-least-functionality-execute-package-management-process-in-container.yaml
@@ -12,35 +12,17 @@ spec:
   severity: 5
   process:
     matchPaths:
-    - path: /usr/bin/apt
-    - path: /usr/bin/apt-get
-    - path: /bin/apt-get
-    - path: /sbin/apk
-    - path: /bin/apt
-    - path: /usr/bin/dpkg
-    - path: /bin/dpkg
-    - path: /usr/bin/gdebi
-    - path: /bin/gdebi
-    - path: /usr/bin/make
-    - path: /bin/make
-    - path: /usr/bin/yum
-    - path: /bin/yum
-    - path: /usr/bin/rpm
-    - path: /bin/rpm
-    - path: /usr/bin/dnf
-    - path: /bin/dnf
-    - path: /usr/bin/pacman
-    - path: /usr/sbin/pacman
-    - path: /bin/pacman
-    - path: /sbin/pacman
-    - path: /usr/bin/makepkg
-    - path: /usr/sbin/makepkg
-    - path: /bin/makepkg
-    - path: /sbin/makepkg
-    - path: /usr/bin/yaourt
-    - path: /usr/sbin/yaourt
-    - path: /bin/yaourt
-    - path: /sbin/yaourt
-    - path: /usr/bin/zypper
-    - path: /bin/zypper
+    - execname: apt
+    - execname: apt-get
+    - execname: apk
+    - execname: dpkg
+    - execname: gdebi
+    - execname: make
+    - execname: yum
+    - execname: rpm
+    - execname: dnf
+    - execname: pacman
+    - execname: makepkg
+    - execname: yaourt
+    - execname: zypper
   action: Block

--- a/tests/recommend/res/out/wordpress-mysql-wordpress/wordpress-4-8-apache-system-owner-discovery.yaml
+++ b/tests/recommend/res/out/wordpress-mysql-wordpress/wordpress-4-8-apache-system-owner-discovery.yaml
@@ -8,10 +8,10 @@ spec:
   message: System owner discovery command execution denied
   process:
     matchPaths:
-    - path: /usr/bin/who
-    - path: /usr/bin/w
-    - path: /usr/bin/id
-    - path: /usr/bin/whoami
+    - execname: who
+    - execname: w
+    - execname: id
+    - execname: whoami
   selector:
     matchLabels:
       app: wordpress


### PR DESCRIPTION
fixes: [#444](https://github.com/kubearmor/kubearmor-client/issues/444)

1.  Modified policies under `res/out` directory according to the new policy template release.
2.  Added logic to check if the file path within the tar archive starts with "blobs/". If a file path starts with "blobs/", the function recursively calls extractTar to extract its contents.


