### PR TITLE
Fix: Show current status of daemonset in karmor install

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -265,11 +265,29 @@ func checkPods(c *k8s.Client, o Options, i bool) {
 		if cursorcount == len(cursor) {
 			cursorcount = 0
 		}
-		if podno > 0 {
-			fmt.Printf("\r🥳\tKubeArmor Daemonset Deployed!             \n")
-			fmt.Printf("\r🥳\tDone Checking , ALL Services are running!             \n")
-			fmt.Printf("⌚️\tExecution Time : %s \n", time.Since(stime))
+		if podno == 0 {
+			fmt.Printf("\r\tNo pods found!             \n")
 			break
+		}
+		if podno > 0 {
+			allPodsReady := true
+			// This loop will break even if only one of the pod is not ready
+			for _, p := range pods.Items {
+				status, ready := GetRealPodStatus(p)
+				fmt.Printf("\r\tThe pod %s is in %s state             ", p.Name, status)
+				if !ready {
+					allPodsReady = false
+					break
+				}
+			}
+			if !allPodsReady {
+				break
+			} else {
+				fmt.Printf("\r🥳\tKubeArmor Daemonset Deployed!             \n")
+				fmt.Printf("\r🥳\tDone Checking , ALL Services are running!             \n")
+				fmt.Printf("⌚️\tExecution Time : %s \n", time.Since(stime))
+				break
+			}
 		}
 		if !otime.After(time.Now()) {
 			fmt.Printf("\r⌚️\tCheck Incomplete due to Time-Out!                     \n")

--- a/install/install.go
+++ b/install/install.go
@@ -271,18 +271,26 @@ func checkPods(c *k8s.Client, o Options, i bool) {
 		}
 		if podno > 0 {
 			allPodsReady := true
+			podsWaiting := false
 			// This loop will break even if only one of the pod is not ready
 			for _, p := range pods.Items {
-				status, ready := GetRealPodStatus(p)
+				status, ready, waiting := GetRealPodStatus(p)
 				fmt.Printf("\r\tThe pod %s is in %s state             ", p.Name, status)
-				if !ready {
+				if !ready && !waiting {
 					allPodsReady = false
+					podsWaiting = false
+					break
+				} else if !ready && waiting {
+					allPodsReady = false
+					podsWaiting = true
 					break
 				}
 			}
-			if !allPodsReady {
+			if !allPodsReady && !podsWaiting {
 				break
-			} else {
+			} else if !allPodsReady && podsWaiting {
+				continue
+			} else if allPodsReady && !podsWaiting {
 				fmt.Printf("\r🥳\tKubeArmor Daemonset Deployed!             \n")
 				fmt.Printf("\r🥳\tDone Checking , ALL Services are running!             \n")
 				fmt.Printf("⌚️\tExecution Time : %s \n", time.Since(stime))
@@ -336,10 +344,14 @@ func checkPods(c *k8s.Client, o Options, i bool) {
 // This accumulates the overall status of pod. A pod may be running but it's containers might not
 // It will return the reason and a boolean which will be true only if all the containers of pod are running
 // The reason is wholesome status of the pod. It may be Running/CrashLoopBackOff or any other state
-func GetRealPodStatus(pod corev1.Pod) (string, bool) {
+// Another returning variable is pending, It is true if phase of Pod is Pending but if container state is waiting it will
+// return pod's pending phase as false! This is because Pending pod can have many reasons and it can become Running
+// in future but waiting container means there is some problem in container
+func GetRealPodStatus(pod corev1.Pod) (string, bool, bool) {
 	status := pod.Status.Phase
 	reason := string(status)
 	var podReady = false
+	var podPending = false
 	if status == corev1.PodRunning {
 		for _, containerStatus := range pod.Status.ContainerStatuses {
 			if !containerStatus.Ready {
@@ -348,13 +360,15 @@ func GetRealPodStatus(pod corev1.Pod) (string, bool) {
 				} else if containerStatus.State.Terminated != nil {
 					reason = containerStatus.State.Terminated.Reason
 				}
-				return reason, false
+				return reason, false, false
 			} else {
 				podReady = true
 			}
 		}
+	} else if status == corev1.PodPending {
+		return reason, podReady, true
 	}
-	return reason, podReady
+	return reason, podReady, podPending
 }
 
 func checkPodsLegacy(c *k8s.Client, o Options) {

--- a/install/install.go
+++ b/install/install.go
@@ -333,6 +333,30 @@ func checkPods(c *k8s.Client, o Options, i bool) {
 	}
 }
 
+// This accumulates the overall status of pod. A pod may be running but it's containers might not
+// It will return the reason and a boolean which will be true only if all the containers of pod are running
+// The reason is wholesome status of the pod. It may be Running/CrashLoopBackOff or any other state
+func GetRealPodStatus(pod corev1.Pod) (string, bool) {
+	status := pod.Status.Phase
+	reason := string(status)
+	var podReady = false
+	if status == corev1.PodRunning {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if !containerStatus.Ready {
+				if containerStatus.State.Waiting != nil {
+					reason = containerStatus.State.Waiting.Reason
+				} else if containerStatus.State.Terminated != nil {
+					reason = containerStatus.State.Terminated.Reason
+				}
+				return reason, false
+			} else {
+				podReady = true
+			}
+		}
+	}
+	return reason, podReady
+}
+
 func checkPodsLegacy(c *k8s.Client, o Options) {
 	cursor := [4]string{"|", "/", "—", "\\"}
 	fmt.Printf("😋\tChecking if KubeArmor pods are running...\n")


### PR DESCRIPTION
Fixes: #443 
This change will now show the status of pods. The only doubt is what to do in `Pending` state of pod? Currently it will wait for the pod to be `Running` or `Failed`. If Pod is running but container is not (due to `CrashLoopBackOff` or something else) it will mark pod as not running and show the reason and break the loop! Please see this for reference:

![Screenshot from 2024-07-24 22-57-47](https://github.com/user-attachments/assets/6ebdb922-2116-4382-b0a0-965be8ffb31c)
