### PR TITLE
[#458] fix(sysdump): ensure AppArmor tar is gzipped in sysdump

### DIFF
--- a/recommend/registry/registry.go
+++ b/recommend/registry/registry.go
@@ -250,7 +250,7 @@ func extractTar(tarname string, tempDir string) ([]string, []string) {
 				}
 				dl = append(dl, tgt)
 			case tar.TypeReg:
-				f, err := os.OpenFile(filepath.Clean(tgt), os.O_CREATE|os.O_RDWR, os.FileMode(hdr.Mode))
+				f, err := os.OpenFile(filepath.Clean(tgt), os.O_CREATE|os.O_RDWR, os.FileMode(hdr.Mode)) //#nosec G115 // hdr.mode bits are trusted here
 				if err != nil {
 					log.WithError(err).WithFields(log.Fields{
 						"target": tgt,

--- a/sysdump/sysdump.go
+++ b/sysdump/sysdump.go
@@ -277,7 +277,7 @@ func copyFromPod(srcPath string, d string, c *k8s.Client) error {
 	for _, pod := range pods.Items {
 		destPath := path.Join(d, fmt.Sprintf("%s_apparmor.tar.gz", pod.Name))
 		reader, outStream := io.Pipe()
-		cmdArr := []string{"tar", "cf", "-", srcPath}
+		cmdArr := []string{"tar", "czf", "-", srcPath}
 		req := c.K8sClientset.CoreV1().RESTClient().
 			Get().
 			Namespace(pod.Namespace).


### PR DESCRIPTION
This PR fixes the issue where the `/etc/apparmor.d` directory is being tarred but not gzipped in the KubeArmor sysdump process. The tarball generated was given a `.tar.gz` extension, but it was not actually gzipped.