### PR TITLE
Add sysdump support for non-Kubernetes (process/VM) mode

### DIFF
--- a/cmd/sysdump.go
+++ b/cmd/sysdump.go
@@ -26,4 +26,5 @@ var sysdumpCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(sysdumpCmd)
 	sysdumpCmd.Flags().StringVarP(&dumpOptions.Filename, "file", "f", "", "output file to use")
+	sysdumpCmd.Flags().BoolVar(&dumpOptions.NonK8s, "nonk8s", false, "Collect sysdump for non-Kubernetes (process/VM) environments")
 }


### PR DESCRIPTION

- Fixes: [#499](https://github.com/kubearmor/kubearmor-client/issues/499)

### What was done

- Implemented sysdump collection for non-Kubernetes (process/VM) environments.
- In non-k8s mode, sysdump collects:
  - AppArmor profiles
  - OS and kernel info
  - KubeArmor journal logs (if available)
  - Probe data (skipped if no k8s client)
- Output is packaged as a zip file, similar to k8s mode.

### How it works

- Run: `./karmor sysdump --nonk8s`
- The tool collects available diagnostics and skips missing files gracefully.
- If a k8s client is not available, probe data collection is skipped to avoid a crash.

### Why probe data is skipped in non-k8s mode

- The probe code (`probe.PrintProbeResultCmd`) expects a valid k8s client.
- Passing `nil`  was causing a segmentation fault  so i wrote a logic such that it should now skip it in non k8s mode but it can be implemented properly in future 



### Example output

- See attached screenshot for the sysdump output below .

![image](https://github.com/user-attachments/assets/e4d2df9d-a692-46ba-a73c-47a8de292e79)

-contents of `os-release.txt` are as follows (Just for a glimpse !) 
```txt 
PRETTY_NAME="Ubuntu 22.04.5 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.5 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
```

