### PR TITLE
feat: Refactored long description for install, log, policy and profile commands

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -23,20 +23,6 @@ var installCmd = &cobra.Command{
 This command bootstraps KubeArmor in your environment by deploying all necessary components
 and configuring them according to the options you specify. It supports two primary modes:
 
-  • Kubernetes mode (default)
-    – Deploys the KubeArmor Operator, Controller, Relay Server, and DaemonSets
-      into the target cluster.
-    – Honors flags like --namespace, --image, --tag, --operator-image, --controller-image,
-      --relay-image, and visibility/audit/block posture settings.
-    – Use --legacy to invoke the legacy installer path for clusters that don’t support
-      Operator‑based installation.
-
-  • Non‑Kubernetes mode (--nonk8s)
-    – Installs KubeArmor as a standalone service on a host or VM.
-    – Automatically selects Docker or systemd VM mode based on host capabilities,
-      or force a mode with --vm-mode (docker|systemd).
-    – Supports secure container monitoring, host‑audit/host‑block posture, and
-      telemetry visibility flags just like Kubernetes mode.
 
 Examples:
   # Install with default settings into namespace "kubearmor"

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -20,31 +20,6 @@ This command connects to a running KubeArmor instance (in‑cluster or remote) o
 continuously prints the events you care about. You can control the connection security,
 select which namespaces or containers to watch, and format the output to suit your workflow.
 
-Connection Options:
-  • --gRPC <port>          port of the KubeArmor gRPC server (port)
-  • --secure                  use mutual TLS for the gRPC connection
-  • --tlsCertPath <path>      local directory containing ca.crt, client.crt & client.key
-  • --tlsCertProvider <mode>  certificate provisioning: “self” (auto‑generate) or “external”
-  • --readCAFromSecret        fetch CA cert from in‑cluster secret (default true)
-
-Output Control:
-  • --msgPath <path|stdout|none>   where to write raw event messages
-  • --logPath <path|stdout|none>   where to write human‑readable alerts & logs
-  • --output, -o <text|json|pretty-json>  choose your output format
-  • --json                       shorthand to force JSON output
-
-Filtering:
-  • --logFilter <policy|system|all>  type of logs to receive (default “policy” i.e alerts)
-  • --namespace, -n <ns>             only show events for this Kubernetes namespace
-  • --operation <Process|File|Network> filter by operation type
-  • --logType <ContainerLog|HostLog>  filter by log source
-  • --container <name>                filter by container name
-  • --pod <name>                      filter by pod name
-  • --resource <cmd>                  filter by executed command
-  • --source <binary>                 filter by system binary path
-  • --labels, -l <key=val,…>          label selectors to narrow pods/services
-  • --limit <n>                       maximum number of events to print (0 for unlimited)
-
 Examples:
   # Stream all policy‑related events in JSON by connecting to local kubearmor instance:
   karmor logs --gRPC 32767 --json --logFilter policy

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -23,13 +23,6 @@ The “policy” command lets you add, delete, and later list or update enforcem
 when running KubeArmor outside a Kubernetes cluster. Policies are defined in YAML and 
 sent over gRPC to the local KubeArmor agent.
 
-Subcommands:
-  • add     Apply a new policy from a YAML file (kubearmor vm policy add <file>)
-  • delete  Remove an existing policy by its YAML file (kubearmor vm policy delete <file>)
-
-Global Flags:
-  • --gRPC <address>   Address of the KubeArmor gRPC server (host:port)
-
 Examples:
   # Apply a file‑access policy on a standalone host:
   karmor vm policy add ./file-access.yaml --gRPC 127.0.0.1:50051
@@ -37,9 +30,6 @@ Examples:
   # Remove that policy when finished:
   karmor vm policy delete ./file-access.yaml --gRPC 127.0.0.1:50051
 
-See each subcommand’s help for more details:
-  karmor vm policy add --help
-  karmor vm policy delete --help
 `,
 }
 

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -18,23 +18,12 @@ The TUI presents separate tabs for File, Network, and Syscall events. Use the Ta
 to switch between each view. Within any tab, press "e" to export the currently displayed data
 to a JSON file (saved in the current directory as ProfileSummary/{operation}.json).
 
-Filtering Options:
-  • --gRPC <port>             port of the KubeArmor gRPC server (port)
-  • --namespace, -n <namespace>  only show logs from this Kubernetes namespace
-  • --pod <pod-name>             only show logs from this pod
-  • --container, -c <name>       only show logs from this container
-
 Usage Examples:
   # Start the TUI connecting to a local agent:
   karmor profile --gRPC 32737
 
   # Filter to namespace "prod" and container "nginx":
   karmor profile -n prod -c nginx 
-
-Controls:
-  • Tab / Shift+Tab   switch between File, Network, and Syscall views  
-  • e                 export current tab’s data as JSON  
-  • Ctrl+C        quit the TUI  
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		profileclient.Start()


### PR DESCRIPTION
Fix for Issue #500 

Refactored the Long descriptions for certain CLI commands (install, log, policy and profile) from this [commit](https://github.com/kubearmor/kubearmor-client/commit/ec130453cee6fbdc7296b992d98171f93a47487c) to contain only:

- Command overview
- Example for usage