### PR TITLE
update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubearmor/kubearmor-client
 
-go 1.24.5
+go 1.24.9
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
@@ -8,7 +8,7 @@ require (
 	github.com/docker/docker v28.3.1+incompatible
 	github.com/fatih/color v1.18.0
 	github.com/json-iterator/go v1.1.12
-	github.com/kubearmor/KubeArmor/protobuf v0.0.0-20250707142851-6b7fc953dd6c
+	github.com/kubearmor/KubeArmor/protobuf v0.0.0-20251112065124-b3d682e08d62
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/moby/term v0.5.2
 	github.com/olekukonko/tablewriter v0.0.5
@@ -102,6 +102,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/kubearmor/KubeArmor/pkg/KubeArmorController v0.0.0-20250707142851-6b7
 github.com/kubearmor/KubeArmor/pkg/KubeArmorController v0.0.0-20250707142851-6b7fc953dd6c/go.mod h1:xekCBFS6h63sH25RJaQZiPbCJ7HDKGIk9P1f2ZhVExU=
 github.com/kubearmor/KubeArmor/pkg/KubeArmorOperator v0.0.0-20250707142851-6b7fc953dd6c h1:QYmtWVDeBULE6zUowfbCTSlbaHRHhYO+H9isgICYWt0=
 github.com/kubearmor/KubeArmor/pkg/KubeArmorOperator v0.0.0-20250707142851-6b7fc953dd6c/go.mod h1:9TkYHGVKqvHJKn4RhcHq0pv12jbaogpdlMciFfzZjeI=
-github.com/kubearmor/KubeArmor/protobuf v0.0.0-20250707142851-6b7fc953dd6c h1:DnQKvgM0vJUwbUY+riDtM2NZSFLImgNRlZPUd/ZMrYw=
-github.com/kubearmor/KubeArmor/protobuf v0.0.0-20250707142851-6b7fc953dd6c/go.mod h1:ZQIx9XAMhZ+D3obBOaCr62DwcxpxLPUHSkLqECovA2c=
+github.com/kubearmor/KubeArmor/protobuf v0.0.0-20251112065124-b3d682e08d62 h1:2ve8oG5GxO0R4veMP6Af63nh5CyBcx56OTp415txSdA=
+github.com/kubearmor/KubeArmor/protobuf v0.0.0-20251112065124-b3d682e08d62/go.mod h1:PyS1HDa7oXyxqXYvuLHphlYGcCoB3eLXWt+TwgUDJV0=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq6+3iTQz8KNCLtVX6idSoTLdUw=
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=

--- a/log/logClient.go
+++ b/log/logClient.go
@@ -450,6 +450,7 @@ func WatchTelemetryHelper(arr []byte, t string, o Options) {
 			"Operation",
 			"Action",
 			"Data",
+			"EventData",
 			"Enforcer",
 			"Result",
 		}


### PR DESCRIPTION
Update protobuf dependencies to support the new `EventData` field.

```json
{
  "Timestamp": 1763018758,
  "UpdatedTime": "2025-11-13T07:25:58.151185Z",
  "ClusterName": "default",
  "HostName": "ubuntu",
  "ParentProcessName": "/usr/lib/systemd/systemd",
  "ProcessName": "/var/lib/rancher/k3s/data/2d4ca2a3c814dfba0168e2818dfbd81859974b1381420eccd4d9e7ed39c11be3/bin/k3s",
  "HostPPID": 1,
  "HostPID": 1220,
  "PPID": 0,
  "PID": 1220,
  "UID": 0,
  "Type": "HostLog",
  "Source": "/var/lib/rancher/k3s/data/2d4ca2a3c814dfba0168e2818dfbd81859974b1381420eccd4d9e7ed39c11be3/bin/k3s",
  "Operation": "File",
  "Resource": "/var/lib/rancher/k3s/server/manifests/metrics-server",
  "Data": "syscall=SYS_OPENAT fd=-100 flags=O_RDONLY|O_CLOEXEC",
  "EventData": {
    "Fd": "-100",
    "Flags": "O_RDONLY|O_CLOEXEC",
    "Syscall": "SYS_OPENAT"
  },
  "Result": "Passed",
  "Cwd": "/var/lib/rancher/k3s/server/",
  "ExecEvent": {
    "ExecID": "0",
    "ExecutableName": "k3s-server"
  },
  "NodeID": "f39801455594d78b98b7816e37eed6e526c2342d945ba334f6ab6086b49426ee"
}

```