### PR TITLE
test: add unit tests for version command

### DIFF
--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/kubearmor/kubearmor-client/k8s"
+	"github.com/kubearmor/kubearmor-client/selfupdate"
+	core "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8_runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestVersionCmd(t *testing.T) {
+	testCases := []struct {
+		name           string
+		objects        []k8_runtime.Object
+		expectedOutput string
+	}{
+		{
+			name:           "kubernetes off",
+			objects:        nil,
+			expectedOutput: fmt.Sprintf("karmor version %s %s/%s BuildDate=%s\n", selfupdate.GitSummary, runtime.GOOS, runtime.GOARCH, selfupdate.BuildDate),
+		},
+
+		{
+			name:           "kubernetes on",
+			expectedOutput: "kubearmor image (running) version kubearmor",
+			objects: []k8_runtime.Object{
+				&core.Pod{
+					ObjectMeta: meta_v1.ObjectMeta{
+						Namespace: "",
+						Labels:    map[string]string{"kubearmor-app": "kubearmor"},
+					},
+					Spec: core.PodSpec{
+						Containers: []core.Container{
+							{
+								Image: "kubearmor",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(tc.objects...)
+			k8sClient = &k8s.Client{
+				K8sClientset: client,
+			}
+			var buffer bytes.Buffer
+			originalStdout := os.Stdout
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			os.Stdout = w
+			if err := versionCmd.RunE(versionCmd, []string{}); err != nil {
+				t.Fatal(err)
+			}
+
+			os.Stdout = originalStdout
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := io.Copy(&buffer, r); err != nil {
+				t.Fatal(err)
+			}
+
+			out := buffer.String()
+			if !bytes.Contains(buffer.Bytes(), []byte(tc.expectedOutput)) {
+				t.Fatalf("expected output to contain %s but got %s", tc.expectedOutput, string(out))
+			}
+		})
+	}
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -52,11 +52,20 @@ func TestVersionCmd(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := fake.NewClientset(tc.objects...)
+			originalClient := k8sClient
 			k8sClient = &k8s.Client{
 				K8sClientset: client,
 			}
+			defer func() {
+				k8sClient = originalClient
+			}()
 			var buffer bytes.Buffer
 			originalStdout := os.Stdout
+
+			defer func() {
+				os.Stdout = originalStdout
+			}()
+
 			r, w, err := os.Pipe()
 			if err != nil {
 				t.Fatal(err)
@@ -66,7 +75,6 @@ func TestVersionCmd(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			os.Stdout = originalStdout
 			if err := w.Close(); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
### Description
This PR adds table-driven unit tests for the `karmor version` command to improve CLI test coverage.

**Key Implementation Details:**
* Utilized `k8s.io/client-go/kubernetes/fake` to inject a mock `corev1.Pod` with the `kubearmor-app=kubearmor` label to simulate an active KubeArmor deployment.
* Captured `os.Stdout` via `os.Pipe` to run assertions against the printed output.
* Wrapped state overrides (`k8sClient` and `os.Stdout`) in `defer` blocks to ensure safe restoration even if the test fails.

Fixes #519 

### How Has This Been Tested?
Ran the tests locally completely disconnected from any cluster/k3d environment to verify the offline isolation:
`go test -v ./cmd -run TestVersionCmd`