### PR TITLE
Add `karmor discover --type` filter for network, file, and process policies

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Authors of KubeArmor
+
+package cmd
+
+import (
+	profileclient "github.com/kubearmor/kubearmor-client/profile/Client"
+	"github.com/spf13/cobra"
+)
+
+// discoverCmd represents the discover command
+var discoverCmd = &cobra.Command{
+	Use:   "discover",
+	Short: "Discover policies from KubeArmor logs",
+	Long: `Discover policies from live KubeArmor telemetry in an interactive terminal UI.
+
+The UI presents separate tabs for Process, File, Network, and Syscall events. Use the Tab key
+to switch between each view. The --type flag can narrow discovery to a single policy category:
+network, file, or process.
+
+Filtering Options:
+  • --gRPC <port>               port of the KubeArmor gRPC server (port)
+  • --namespace, -n <namespace>  only show logs from this Kubernetes namespace
+  • --pod <pod-name>            only show logs from this pod
+  • --container, -c <name>      only show logs from this container
+  • --type, -t <type>           filter by policy type: network | file | process
+
+Usage Examples:
+  # Start the UI connecting to a local agent:
+  karmor discover --gRPC 32737
+
+  # Filter to namespace "prod" and container "nginx":
+  karmor discover -n prod -c nginx
+
+  # Show only network policy discoveries:
+  karmor discover --type network
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return profileclient.Start()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(discoverCmd)
+	discoverCmd.Flags().StringVar(&profileclient.ProfileOpts.GRPC, "gRPC", "", "use gRPC")
+	discoverCmd.Flags().StringVarP(&profileclient.ProfileOpts.Namespace, "namespace", "n", "", "Filter using namespace")
+	discoverCmd.Flags().StringVar(&profileclient.ProfileOpts.Pod, "pod", "", "Filter using Pod name")
+	discoverCmd.Flags().StringVarP(&profileclient.ProfileOpts.Container, "container", "c", "", "name of the container ")
+	discoverCmd.Flags().StringVarP(&profileclient.ProfileOpts.PolicyType, "type", "t", "", "Filter by policy type: network | file | process")
+	discoverCmd.Flags().BoolVar(&profileclient.ProfileOpts.Save, "save", false, "Save Profile data in json format")
+}

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -37,8 +37,7 @@ Controls:
   • Ctrl+C        quit the TUI  
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		profileclient.Start()
-		return nil
+		return profileclient.Start()
 	},
 }
 
@@ -48,5 +47,6 @@ func init() {
 	profilecmd.Flags().StringVarP(&profileclient.ProfileOpts.Namespace, "namespace", "n", "", "Filter using namespace")
 	profilecmd.Flags().StringVar(&profileclient.ProfileOpts.Pod, "pod", "", "Filter using Pod name")
 	profilecmd.Flags().StringVarP(&profileclient.ProfileOpts.Container, "container", "c", "", "name of the container ")
+	profilecmd.Flags().StringVarP(&profileclient.ProfileOpts.PolicyType, "type", "t", "", "Filter by policy type: network | file | process")
 	profilecmd.Flags().BoolVar(&profileclient.ProfileOpts.Save, "save", false, "Save Profile data in json format")
 }

--- a/profile/Client/profileClient.go
+++ b/profile/Client/profileClient.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -16,7 +17,6 @@ import (
 	"github.com/evertras/bubble-table/table"
 	pb "github.com/kubearmor/KubeArmor/protobuf"
 	profile "github.com/kubearmor/kubearmor-client/profile"
-	log "github.com/sirupsen/logrus"
 )
 
 // Column keys
@@ -60,14 +60,45 @@ var (
 
 // Options for filter
 type Options struct {
-	Namespace string
-	Pod       string
-	GRPC      string
-	Container string
-	Save      bool
+	Namespace  string
+	Pod        string
+	GRPC       string
+	Container  string
+	PolicyType string
+	Save       bool
 }
 
 var ProfileOpts Options
+
+func normalizePolicyType(policyType string) (string, error) {
+	policyType = strings.ToLower(strings.TrimSpace(policyType))
+	switch policyType {
+	case "", "network", "file", "process":
+		return policyType, nil
+	default:
+		return "", fmt.Errorf("invalid --type value %q; valid options are: network, file, process", policyType)
+	}
+}
+
+func visibleTabsForPolicyType(policyType string) []string {
+	switch policyType {
+	case "network":
+		return []string{"Network"}
+	case "file":
+		return []string{"File"}
+	case "process":
+		return []string{"Process"}
+	default:
+		return []string{"Process", "File", "Network", "Syscall"}
+	}
+}
+
+func operationAllowed(policyType string, operation string) bool {
+	if policyType == "" {
+		return true
+	}
+	return strings.EqualFold(policyType, strings.ToLower(operation))
+}
 
 // Model for main Bubble Tea
 type Model struct {
@@ -144,7 +175,7 @@ func (m Model) Init() tea.Cmd {
 }
 
 // NewModel initializates new bubbletea model
-func NewModel() Model {
+func NewModel(policyType string) Model {
 	model := Model{
 		File:         table.New(generateColumns("File")).WithBaseStyle(styleBase).WithPageSize(30).Filtered(true),
 		FileRows:     []table.Row{},
@@ -164,11 +195,20 @@ func NewModel() Model {
 
 		tabs: &tabs{
 			active: "Lip Gloss",
-			items:  []string{"Process", "File", "Network", "Syscall"},
+			items:  visibleTabsForPolicyType(policyType),
 		},
 		keys:  keys,
 		help:  help.New(),
 		state: processview,
+	}
+
+	switch policyType {
+	case "file":
+		model.state = fileview
+	case "network":
+		model.state = networkview
+	case "process":
+		model.state = processview
 	}
 
 	return model
@@ -266,7 +306,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 	case pb.Log:
-		if isCorrectLog(msg) {
+		if isCorrectLog(msg) && operationAllowed(ProfileOpts.PolicyType, msg.Operation) {
 			m.updateTableWithNewEntry(msg)
 		}
 
@@ -441,10 +481,16 @@ type Profile struct {
 }
 
 // Start entire TUI
-func Start() {
-	p := tea.NewProgram(NewModel(), tea.WithAltScreen())
+func Start() error {
+	policyType, err := normalizePolicyType(ProfileOpts.PolicyType)
+	if err != nil {
+		return err
+	}
+	ProfileOpts.PolicyType = policyType
+
+	p := tea.NewProgram(NewModel(policyType), tea.WithAltScreen())
 	go func() {
-		err := profile.GetLogs(ProfileOpts.GRPC)
+		err := profile.GetLogs(ProfileOpts.GRPC, policyType)
 		if err != nil {
 			p.Quit()
 			profile.ErrChan <- err
@@ -453,12 +499,12 @@ func Start() {
 
 	os.Stderr = nil
 	if _, err := p.Run(); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	select {
 	case err := <-profile.ErrChan:
-		log.Errorf("failed to start observer. Error=%s", err.Error())
+		return err
 	default:
-		break
+		return nil
 	}
 }

--- a/profile/Client/profileClient_test.go
+++ b/profile/Client/profileClient_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Authors of KubeArmor
+
+package profileclient
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizePolicyType(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      string
+		wantError bool
+	}{
+		{name: "empty", input: "", want: ""},
+		{name: "network lowercase", input: "network", want: "network"},
+		{name: "file uppercase", input: "FILE", want: "file"},
+		{name: "process trimmed", input: "  process ", want: "process"},
+		{name: "invalid", input: "syscall", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizePolicyType(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizePolicyType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisibleTabsForPolicyType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "all", input: "", want: []string{"Process", "File", "Network", "Syscall"}},
+		{name: "network", input: "network", want: []string{"Network"}},
+		{name: "file", input: "file", want: []string{"File"}},
+		{name: "process", input: "process", want: []string{"Process"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := visibleTabsForPolicyType(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("visibleTabsForPolicyType(%q) = %#v, want %#v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOperationAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		policyType string
+		operation  string
+		want       bool
+	}{
+		{name: "all allowed", policyType: "", operation: "Network", want: true},
+		{name: "matching type", policyType: "network", operation: "Network", want: true},
+		{name: "case insensitive", policyType: "file", operation: "FILE", want: true},
+		{name: "mismatch", policyType: "process", operation: "Network", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := operationAllowed(tt.policyType, tt.operation)
+			if got != tt.want {
+				t.Fatalf("operationAllowed(%q, %q) = %v, want %v", tt.policyType, tt.operation, got, tt.want)
+			}
+		})
+	}
+}

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -6,6 +6,7 @@ package profile
 
 import (
 	"errors"
+	"strings"
 
 	pb "github.com/kubearmor/KubeArmor/protobuf"
 	"github.com/kubearmor/kubearmor-client/k8s"
@@ -22,7 +23,7 @@ var ErrChan chan error
 var EventChan = make(chan pb.Log)
 
 // GetLogs to fetch logs
-func GetLogs(grpc string) error {
+func GetLogs(grpc string, operationFilter string) error {
 	errCh := KarmorProfileStart("system", grpc)
 	var err error
 	if eventChan == nil {
@@ -38,6 +39,9 @@ func GetLogs(grpc string) error {
 				err := protojson.Unmarshal(evtin.Data, &log)
 				if err != nil {
 					return err
+				}
+				if operationFilter != "" && !strings.EqualFold(log.Operation, operationFilter) {
+					continue
 				}
 				EventChan <- log
 			} else {


### PR DESCRIPTION
This change adds a `--type` / `-t` flag to the discover flow so users can filter discovered policy output by policy category.

Fix: #161 