### PR TITLE
adding maintainers md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,15 @@
+# Maintainers
+
+This is the official maintainers list for kubearmor-client.
+The list is sorted in ascending order.
+
+## kubearmor-client Maintainers
+
+* [Achref Ben Saad](https://github.com/achrefbensaad) (AccuKnox)
+* [Ankur Kothiwal](https://github.com/Ankurk99) (CERN)
+* [Anurag Kumar](https://github.com/kranurag7) (Independent)
+* [Barun Acharya](https://github.com/daemon1024) (AccuKnox)
+* [Jaehyun Nam](https://github.com/nam-jaehyun) (Dankook Univ)
+* [Rahul Jadhav](https://github.com/nyrahul) (AccuKnox)
+* [Ramakant Sharma](https://github.com/rksharma95) (AccuKnox)
+* [Rudraksh Pareek](https://github.com/DelusionalOptimist) (CERN) 


### PR DESCRIPTION
Earlier, the MAINTAINERS.md was missing. I have added it by copying it same from the KubeArmor.

Fixes #528 