### PR TITLE
fix(install): honor --kubeconfig/--context in operator install/uninstall

### DIFF
--- a/install/install.go
+++ b/install/install.go
@@ -960,6 +960,10 @@ func K8sInstaller(c *k8s.Client, o Options) error {
 	kubearmorConfig, postureSettings := getOperatorCR(o)
 	values := getOperatorConfig(o)
 	settings := cli.New()
+	// Honor the --kubeconfig/--context flags so the Helm-based operator install
+	// targets the same cluster as the rest of the client (see k8s.ConnectK8sClient).
+	settings.KubeConfig = k8s.KubeConfig
+	settings.KubeContext = k8s.ContextName
 
 	actionConfig := actionConfigInit(ns, settings)
 
@@ -1529,6 +1533,10 @@ func K8sLegacyUninstaller(c *k8s.Client, o Options) error {
 func K8sUninstaller(c *k8s.Client, o Options) error {
 	var ns string
 	settings := cli.New()
+	// Honor the --kubeconfig/--context flags so the Helm-based operator uninstall
+	// targets the same cluster as the rest of the client (see k8s.ConnectK8sClient).
+	settings.KubeConfig = k8s.KubeConfig
+	settings.KubeContext = k8s.ContextName
 
 	actionConfig := actionConfigInit("", settings)
 	statusClient := action.NewStatus(actionConfig)


### PR DESCRIPTION
## Problem

When `--kubeconfig` or `--context` is passed to `karmor install` / `karmor uninstall`, the operator-based (non-legacy) path still targets the default cluster/context, so KubeArmor cannot be installed into another cluster. The legacy path (`--legacy`) works correctly. Fixes #483.

## Root cause

`K8sInstaller` and `K8sUninstaller` build Helm settings with `cli.New()`, which resolves the kubeconfig/context from the environment (default `~/.kube/config` + current-context) and ignores the global `--kubeconfig`/`--context` flags. The rest of the client uses `k8s.ConnectK8sClient()`, which *does* honor those flags — which is exactly why the legacy path works but the Helm-driven operator path does not.

## Fix

Thread `k8s.KubeConfig` and `k8s.ContextName` into the Helm `EnvSettings` at both sites, so the Helm actions target the same cluster as the rest of the client.

## Testing

- `go build ./...` passes; `gofmt` clean.
- Recommend a two-context runtime check before merge: with a second context configured, `karmor install --context <other>` should provision resources in `<other>` (verify with `kubectl --context <other> get pods -n kubearmor`), while a current-context install remains unchanged.
