### PR TITLE
fix(install): remove kubearmornetworkpolicies CRD on force uninstall

### DIFF
--- a/install/customResource.go
+++ b/install/customResource.go
@@ -13,6 +13,7 @@ var (
 	hspName = "kubearmorhostpolicies.security.kubearmor.com"
 	cspName = "kubearmorclusterpolicies.security.kubearmor.com"
 	kocName = "kubearmorconfigs.operator.kubearmor.com"
+	knpName = "kubearmornetworkpolicies.security.kubearmor.com"
 )
 
 // CreateCustomResourceDefinition creates the CRD and add it into Kubernetes.

--- a/install/install.go
+++ b/install/install.go
@@ -244,7 +244,7 @@ func printBar(msg string, total int) int {
 
 func printAnimation(msg string, flag bool) int {
 	clearLine(90)
-	fmt.Printf(msg + "\n")
+	fmt.Printf("%s\n", msg)
 	if verify {
 		if flag {
 			progress++
@@ -1327,7 +1327,7 @@ func listPods(c *k8s.Client) {
 		}
 	}
 	if cnt != 0 {
-		fmt.Println("ℹ️   Following pods will get restarted with karmor uninstall --force: \n")
+		fmt.Printf("ℹ️   Following pods will get restarted with karmor uninstall --force: \n\n")
 		table.Render()
 	}
 }
@@ -1516,6 +1516,14 @@ func K8sLegacyUninstaller(c *k8s.Client, o Options) error {
 			fmt.Printf("CRD %s not found\n", hspName)
 		}
 
+		fmt.Printf("CRD %s\n", knpName)
+		if err := c.APIextClientset.ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), knpName, metav1.DeleteOptions{}); err != nil {
+			if !strings.Contains(err.Error(), "not found") {
+				return err
+			}
+			fmt.Printf("CRD %s not found\n", knpName)
+		}
+
 		removeAnnotations(c)
 	}
 
@@ -1595,6 +1603,14 @@ func K8sUninstaller(c *k8s.Client, o Options) error {
 				return err
 			}
 			fmt.Printf("CRD %s not found\n", hspName)
+		}
+
+		fmt.Printf("❌  Removing CRD %s\n", knpName)
+		if err := c.APIextClientset.ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), knpName, metav1.DeleteOptions{}); err != nil {
+			if !strings.Contains(err.Error(), "not found") {
+				return err
+			}
+			fmt.Printf("CRD %s not found\n", knpName)
 		}
 
 		removeAnnotations(c)


### PR DESCRIPTION
**Purpose of PR?**:
Ensure the `kubearmornetworkpolicies.security.kubearmor.com` CRD is completely cleaned up when executing `karmor uninstall --force`. Previously, it was left behind while other KubeArmor CRDs (KSP, HSP, CSP, KOC) were deleted.

Fixes #533

**Does this PR introduce a breaking change?**
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Compiled the client CLI binary locally and verified it executes without error.
- Verified syntax, formatting, and codebase guidelines pass cleanly (`go vet`, `gofmt`).
- Ran security static scanning with `gosec` (0 issues found).

**Additional information for reviewer?** :
None

**Checklist:**
- [x] Bug fix. Fixes #533
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] PR Title follows the convention of `<type>(<scope>): <subject>`
- [ ] Commit has unit tests
- [ ] Commit has integration tests
