### PR TITLE
fix(recommend): replace underscores with hyphens in generated policy names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 
 .PHONY: test
 test:
-	cd $(CURDIR); go test -v $(go list ./... | grep -v recommend)
+	cd $(CURDIR); go test -v ./recommend/image/... $(shell go list ./... | grep -v recommend)
 
 .PHONY: protobuf
 vm-protobuf:

--- a/recommend/image/image.go
+++ b/recommend/image/image.go
@@ -204,6 +204,7 @@ func mkPathFromTag(tag string) string {
 		"\\", "-",
 		".", "-",
 		"@", "-",
+		"_", "-",
 	)
 	return r.Replace(tag)
 }

--- a/recommend/image/image_test.go
+++ b/recommend/image/image_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Authors of KubeArmor
+
+package image
+
+import (
+	"testing"
+)
+
+func TestMkPathFromTag(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			// Issue #547: underscores in tag produce invalid RFC1123 names
+			name:  "underscores in tag are replaced with hyphens",
+			input: "specifyconsortium/specify7-service:v7_12_0_7_base",
+			want:  "specifyconsortium-specify7-service-v7-12-0-7-base",
+		},
+		{
+			name:  "underscore only in tag",
+			input: "myimage:v1_0",
+			want:  "myimage-v1-0",
+		},
+		{
+			name:  "underscore in repo name",
+			input: "my_org/myimage:latest",
+			want:  "my-org-myimage-latest",
+		},
+		{
+			// Regression: existing characters must still be replaced
+			name:  "colon and slash are replaced (regression)",
+			input: "ubuntu:18.04",
+			want:  "ubuntu-18-04",
+		},
+		{
+			name:  "dots in registry and tag are replaced (regression)",
+			input: "registry.example.com/myimage:1.2.3",
+			want:  "registry-example-com-myimage-1-2-3",
+		},
+		{
+			name:  "at-sign in digest is replaced (regression)",
+			input: "myimage@sha256:abc123",
+			want:  "myimage-sha256-abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mkPathFromTag(tt.input)
+			if got != tt.want {
+				t.Errorf("mkPathFromTag(%q)\n  got:  %q\n  want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #547

`karmor recommend` generates invalid `KubeArmorPolicy` names when image tags contain underscores (e.g. `v7_12_0_7_base`). Kubernetes resource names must follow RFC 1123, which forbids underscores — only lowercase letters, digits, and hyphens are allowed.

## What Changed

- **`recommend/image/image.go`** — Added `"_", "-"` to the `strings.NewReplacer` call inside `mkPathFromTag()`. This is the single function that controls how image tags are turned into policy name segments.
- **`recommend/image/image_test.go`** — New unit test file with 6 test cases: the exact reproduction case from the issue report, two additional underscore variants, and regression tests for all previously handled characters (`/`, `:`, `.`, `@`).
- **`Makefile`** — Updated `make test` to explicitly include `./recommend/image/...` before the `grep -v recommend` exclusion. Previously all packages under `recommend/` were skipped (to avoid e2e tests that need a live cluster), which meant the new unit tests would also be silently skipped by CI.

## Result After This PR

**Before:**
```
karmor recommend -i specifyconsortium/specify7-service:v7_12_0_7_base
# → name: specifyconsortium-specify7-service-v7_12_0_7_base-access-ctrl-permission-mod  ❌
```

**After:**
```
karmor recommend -i specifyconsortium/specify7-service:v7_12_0_7_base
# → name: specifyconsortium-specify7-service-v7-12-0-7-base-access-ctrl-permission-mod  ✅
```

All 6 unit tests pass:
```
--- PASS: TestMkPathFromTag/underscores_in_tag_are_replaced_with_hyphens
--- PASS: TestMkPathFromTag/underscore_only_in_tag
--- PASS: TestMkPathFromTag/underscore_in_repo_name
--- PASS: TestMkPathFromTag/colon_and_slash_are_replaced_(regression)
--- PASS: TestMkPathFromTag/dots_in_registry_and_tag_are_replaced_(regression)
--- PASS: TestMkPathFromTag/at-sign_in_digest_is_replaced_(regression)
PASS  ok  github.com/kubearmor/kubearmor-client/recommend/image
```

Signed-off-by: Gaurav Chaudhary <chaudharygaurav2004@gmail.com>