### PR TITLE
Add API Events streaming support to karmor logs.

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -14,7 +14,7 @@ var logOptions log.Options
 var logCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Observe Logs from KubeArmor",
-	Long: `Stream and filter KubeArmor alerts, system logs, and policy enforcement events.
+	Long: `Stream and filter KubeArmor alerts, system logs, policy enforcement events, and API Observer events.
 
 This command connects to a running KubeArmor instance (in‑cluster or remote) over gRPC and
 continuously prints the events you care about. You can control the connection security,
@@ -24,7 +24,7 @@ Connection Options:
   • --gRPC <port>          port of the KubeArmor gRPC server (port)
   • --secure                  use mutual TLS for the gRPC connection
   • --tlsCertPath <path>      local directory containing ca.crt, client.crt & client.key
-  • --tlsCertProvider <mode>  certificate provisioning: “self” (auto‑generate) or “external”
+  • --tlsCertProvider <mode>  certificate provisioning: "self" (auto‑generate) or "external"
   • --readCAFromSecret        fetch CA cert from in‑cluster secret (default true)
 
 Output Control:
@@ -34,7 +34,7 @@ Output Control:
   • --json                       shorthand to force JSON output
 
 Filtering:
-  • --logFilter <policy|system|all>  type of logs to receive (default “policy” i.e alerts)
+  • --logFilter <policy|system|all|api>  type of logs to receive (default "policy" i.e alerts)
   • --namespace, -n <ns>             only show events for this Kubernetes namespace
   • --operation <Process|File|Network> filter by operation type
   • --logType <ContainerLog|HostLog>  filter by log source
@@ -45,15 +45,27 @@ Filtering:
   • --labels, -l <key=val,…>          label selectors to narrow pods/services
   • --limit <n>                       maximum number of events to print (0 for unlimited)
 
+API Observer Filters (used with --logFilter=api):
+  • --protocol <HTTP|gRPC>           filter by protocol type
+  • --method <GET|POST|...>          filter by HTTP method
+  • --status <2xx|404|5xx|...>       filter by response status code pattern
+  • --minDuration <ms>               filter events with latency >= N milliseconds
+
 Examples:
   # Stream all policy‑related events in JSON by connecting to local kubearmor instance:
   karmor logs --gRPC 32767 --json --logFilter policy
 
-  # Watch only file operations in namespace “prod”:
+  # Watch only file operations in namespace "prod":
   karmor logs -n prod --operation File --logFilter all
 
   # Persist alerts to a file in pretty JSON:
   karmor logs --msgPath stdout --logPath /var/log/kubearmor.json --output pretty-json
+
+  # Stream API Observer events for HTTP requests in namespace "default":
+  karmor logs --logFilter api -n default --protocol HTTP
+
+  # Watch gRPC API events with latency >= 100ms:
+  karmor logs --logFilter api --protocol gRPC --minDuration 100
 
 	Use "karmor logs --help" to see detailed flag descriptions and defaults.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -72,7 +84,7 @@ func init() {
 	logCmd.Flags().BoolVar(&logOptions.ReadCAFromSecret, "readCAFromSecret", true, "true if ca cert to be read from k8s secret on cluster running kubearmor")
 	logCmd.Flags().StringVar(&logOptions.MsgPath, "msgPath", "none", "Output location for messages, {path|stdout|none}")
 	logCmd.Flags().StringVar(&logOptions.LogPath, "logPath", "stdout", "Output location for alerts and logs, {path|stdout|none}")
-	logCmd.Flags().StringVar(&logOptions.LogFilter, "logFilter", "policy", "Filter for what kinds of alerts and logs to receive, {policy|system|all}")
+	logCmd.Flags().StringVar(&logOptions.LogFilter, "logFilter", "policy", "Filter for what kinds of alerts and logs to receive, {policy|system|all|api}")
 	logCmd.Flags().BoolVar(&logOptions.JSON, "json", false, "Flag to print alerts and logs in the JSON format")
 	logCmd.Flags().StringVarP(&logOptions.Output, "output", "o", "text", "Output format: text, json, or pretty-json")
 	logCmd.Flags().StringVarP(&logOptions.Namespace, "namespace", "n", "", "k8s namespace filter")
@@ -84,4 +96,10 @@ func init() {
 	logCmd.Flags().StringVar(&logOptions.Source, "source", "", "binary used by the system ")
 	logCmd.Flags().Uint32Var(&logOptions.Limit, "limit", 0, "number of logs you want to see")
 	logCmd.Flags().StringSliceVarP(&logOptions.Selector, "labels", "l", []string{}, "use the labels to select the endpoints")
+
+	// API Observer specific flags
+	logCmd.Flags().StringVar(&logOptions.Protocol, "protocol", "", "API Observer: filter by protocol (e.g. HTTP, gRPC)")
+	logCmd.Flags().StringVar(&logOptions.Method, "method", "", "API Observer: filter by HTTP method (e.g. GET, POST)")
+	logCmd.Flags().StringVar(&logOptions.StatusPattern, "status", "", "API Observer: filter by status code pattern (e.g. 2xx, 404, 5xx)")
+	logCmd.Flags().Int64Var(&logOptions.MinDurationMs, "minDuration", 0, "API Observer: minimum latency in milliseconds")
 }

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
+	github.com/accuknox/SentryFlow/protobuf/golang v0.0.0-20260514050050-22a4d4f04e17
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/accuknox/SentryFlow/protobuf/golang v0.0.0-20260514050050-22a4d4f04e17 h1:7jturMtAx/IZKRy4uvEgZSlLArrUJkDXjELGm1Juzoo=
+github.com/accuknox/SentryFlow/protobuf/golang v0.0.0-20260514050050-22a4d4f04e17/go.mod h1:9DwSy8aPlq2d01FSpYOCXHlMx2CNWhTwdO7SelLpod0=
 github.com/andybalholm/brotli v1.0.1 h1:KqhlKozYbRtJvsPrrEeXcO+N2l6NYT5A2QAFmSULpEc=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/log/log.go
+++ b/log/log.go
@@ -59,6 +59,12 @@ type Options struct {
 	Limit            uint32
 	Selector         []string
 	EventChan        chan EventInfo // channel to send events on
+
+	// API Observer specific filters
+	Protocol      string // protocol filter for API events (e.g. "HTTP", "gRPC")
+	Method        string // HTTP method filter (e.g. "GET", "POST")
+	StatusPattern string // status code pattern filter (e.g. "2xx", "404")
+	MinDurationMs int64  // minimum latency filter in milliseconds
 }
 
 // StopChan Channel
@@ -152,7 +158,7 @@ func StartObserver(c *k8s.Client, o Options) error {
 		return nil
 	}
 
-	if o.LogFilter != "all" && o.LogFilter != "policy" && o.LogFilter != "system" {
+	if o.LogFilter != "all" && o.LogFilter != "policy" && o.LogFilter != "system" && o.LogFilter != "api" {
 		flag.PrintDefaults()
 		return nil
 	}
@@ -176,36 +182,45 @@ func StartObserver(c *k8s.Client, o Options) error {
 
 	fmt.Fprintf(os.Stderr, "Created a gRPC client (%s)\n", gRPC)
 
-	// do healthcheck
-	if ok := logClient.DoHealthCheck(); !ok {
-		return errors.New("failed to check the liveness of the gRPC server")
-	}
-	fmt.Fprintln(os.Stderr, "Checked the liveness of the gRPC server")
-
-	if o.MsgPath != "none" {
-		// watch messages
-		go logClient.WatchMessages(o.MsgPath, o.JSON)
-		fmt.Fprintln(os.Stderr, "Started to watch messages")
-	}
-
-	err = regexCompile(o)
-	if err != nil {
-		fmt.Print(err)
-		return err
+	// do healthcheck (skip for API observer — it uses a separate gRPC service)
+	if o.LogFilter != "api" {
+		if ok := logClient.DoHealthCheck(); !ok {
+			return errors.New("failed to check the liveness of the gRPC server")
+		}
+		fmt.Fprintln(os.Stderr, "Checked the liveness of the gRPC server")
 	}
 
 	Limitchan = make(chan bool, 2)
-	if o.LogPath != "none" {
-		if o.LogFilter == "all" || o.LogFilter == "policy" {
-			// watch alerts
-			go logClient.WatchAlerts(o)
-			fmt.Fprintln(os.Stderr, "Started to watch alerts")
+
+	if o.LogFilter == "api" {
+		// watch API observer events
+		go logClient.WatchAPIEvents(o)
+		fmt.Fprintln(os.Stderr, "Started to watch API events")
+	} else {
+		if o.MsgPath != "none" {
+			// watch messages
+			go logClient.WatchMessages(o.MsgPath, o.JSON)
+			fmt.Fprintln(os.Stderr, "Started to watch messages")
 		}
 
-		if o.LogFilter == "all" || o.LogFilter == "system" {
-			// watch logs
-			go logClient.WatchLogs(o)
-			fmt.Fprintln(os.Stderr, "Started to watch logs")
+		err = regexCompile(o)
+		if err != nil {
+			fmt.Print(err)
+			return err
+		}
+
+		if o.LogPath != "none" {
+			if o.LogFilter == "all" || o.LogFilter == "policy" {
+				// watch alerts
+				go logClient.WatchAlerts(o)
+				fmt.Fprintln(os.Stderr, "Started to watch alerts")
+			}
+
+			if o.LogFilter == "all" || o.LogFilter == "system" {
+				// watch logs
+				go logClient.WatchLogs(o)
+				fmt.Fprintln(os.Stderr, "Started to watch logs")
+			}
 		}
 	}
 

--- a/log/logClient.go
+++ b/log/logClient.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 
+	apipb "github.com/accuknox/SentryFlow/protobuf/golang"
 	pb "github.com/kubearmor/KubeArmor/protobuf"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
@@ -92,6 +93,9 @@ type Feeder struct {
 	// client
 	client pb.LogServiceClient
 
+	// api observer client
+	apiClient apipb.APIObserverServiceClient
+
 	// messages
 	msgStream pb.LogService_WatchMessagesClient
 
@@ -100,6 +104,9 @@ type Feeder struct {
 
 	// logs
 	logStream pb.LogService_WatchLogsClient
+
+	// api event stream
+	apiEventStream apipb.APIObserverService_GetAPIEventsClient
 
 	// wait group
 	WgClient sync.WaitGroup
@@ -132,39 +139,68 @@ func NewClient(server string, o Options, c kubernetes.Interface) (*Feeder, error
 	}
 	fd.conn = conn
 
-	fd.client = pb.NewLogServiceClient(fd.conn)
+	if o.LogFilter == "api" {
+		// Set up API Observer client and stream
+		fd.apiClient = apipb.NewAPIObserverServiceClient(fd.conn)
 
-	msgIn := pb.RequestMessage{}
-	msgIn.Filter = ""
+		filter := &apipb.APIEventFilter{
+			Namespace: o.Namespace,
+			PodName:   o.PodName,
+		}
+		if o.Protocol != "" {
+			filter.Protocols = []string{o.Protocol}
+		}
+		if o.Method != "" {
+			filter.Methods = []string{o.Method}
+		}
+		if o.StatusPattern != "" {
+			filter.StatusPatterns = []string{o.StatusPattern}
+		}
+		if o.MinDurationMs > 0 {
+			filter.MinDurationMs = o.MinDurationMs
+		}
 
-	if o.MsgPath != "none" {
-		msgStream, err := fd.client.WatchMessages(context.Background(), &msgIn)
+		apiEventStream, err := fd.apiClient.GetAPIEvents(context.Background(), filter)
 		if err != nil {
 			return nil, err
 		}
-		fd.msgStream = msgStream
-	}
+		fd.apiEventStream = apiEventStream
+	} else {
+		// Set up LogService client and streams
+		fd.client = pb.NewLogServiceClient(fd.conn)
 
-	alertIn := pb.RequestMessage{}
-	alertIn.Filter = o.LogFilter
+		msgIn := pb.RequestMessage{}
+		msgIn.Filter = ""
 
-	if o.LogPath != "none" && (alertIn.Filter == "all" || alertIn.Filter == "policy") {
-		alertStream, err := fd.client.WatchAlerts(context.Background(), &alertIn)
-		if err != nil {
-			return nil, err
+		if o.MsgPath != "none" {
+			msgStream, err := fd.client.WatchMessages(context.Background(), &msgIn)
+			if err != nil {
+				return nil, err
+			}
+			fd.msgStream = msgStream
 		}
-		fd.alertStream = alertStream
-	}
 
-	logIn := pb.RequestMessage{}
-	logIn.Filter = o.LogFilter
+		alertIn := pb.RequestMessage{}
+		alertIn.Filter = o.LogFilter
 
-	if o.LogPath != "none" && (logIn.Filter == "all" || logIn.Filter == "system") {
-		logStream, err := fd.client.WatchLogs(context.Background(), &logIn)
-		if err != nil {
-			return nil, err
+		if o.LogPath != "none" && (alertIn.Filter == "all" || alertIn.Filter == "policy") {
+			alertStream, err := fd.client.WatchAlerts(context.Background(), &alertIn)
+			if err != nil {
+				return nil, err
+			}
+			fd.alertStream = alertStream
 		}
-		fd.logStream = logStream
+
+		logIn := pb.RequestMessage{}
+		logIn.Filter = o.LogFilter
+
+		if o.LogPath != "none" && (logIn.Filter == "all" || logIn.Filter == "system") {
+			logStream, err := fd.client.WatchLogs(context.Background(), &logIn)
+			if err != nil {
+				return nil, err
+			}
+			fd.logStream = logStream
+		}
 	}
 
 	fd.WgClient = sync.WaitGroup{}
@@ -482,6 +518,131 @@ func WatchTelemetryHelper(arr []byte, t string, o Options) {
 	if o.LogPath == "stdout" {
 		fmt.Printf("%s", str)
 	} else if o.LogPath != "" {
+		StrToFile(str, o.LogPath)
+	}
+}
+
+// WatchAPIEvents streams API Observer events from the APIObserverService
+func (fd *Feeder) WatchAPIEvents(o Options) error {
+	fd.WgClient.Add(1)
+	defer fd.WgClient.Done()
+
+	if o.Limit > 0 {
+		for i = 0; i < o.Limit; i++ {
+			res, err := fd.apiEventStream.Recv()
+			if err != nil {
+				break
+			}
+
+			str := formatAPIEvent(res, o)
+			writeAPIEventOutput(str, o)
+		}
+		Limitchan <- true
+		return nil
+	}
+
+	for fd.Running {
+		res, err := fd.apiEventStream.Recv()
+		if err != nil {
+			UnblockSignal = err
+			break
+		}
+
+		str := formatAPIEvent(res, o)
+		writeAPIEventOutput(str, o)
+	}
+
+	fmt.Fprintln(os.Stderr, "Stopped WatchAPIEvents")
+	return nil
+}
+
+// formatAPIEvent formats an APIEvent as a string (JSON or human-readable text)
+func formatAPIEvent(res *apipb.APIEvent, o Options) string {
+	if o.JSON || o.Output == "json" {
+		arr, _ := json.Marshal(res)
+		return fmt.Sprintf("%s\n", string(arr))
+	}
+
+	if o.Output == "pretty-json" {
+		arr, _ := json.Marshal(res)
+		var prettyJSON bytes.Buffer
+		if err := json.Indent(&prettyJSON, arr, "", "  "); err == nil {
+			return fmt.Sprintf("%s\n", prettyJSON.String())
+		}
+		return fmt.Sprintf("%s\n", string(arr))
+	}
+
+	// Human-readable text format
+	var sb strings.Builder
+
+	timestamp := ""
+	if res.Metadata != nil {
+		timestamp = fmt.Sprintf("%d", res.Metadata.Timestamp)
+	}
+	sb.WriteString(fmt.Sprintf("== APIEvent / %s ==\n", timestamp))
+
+	if res.Protocol != "" {
+		sb.WriteString(fmt.Sprintf("Protocol: %s\n", res.Protocol))
+	}
+
+	if res.Metadata != nil {
+		if res.Metadata.NodeName != "" {
+			sb.WriteString(fmt.Sprintf("Node: %s\n", res.Metadata.NodeName))
+		}
+	}
+
+	if res.Source != nil {
+		src := res.Source
+		sb.WriteString(fmt.Sprintf("Source: %s/%s (%s:%d)\n", src.Namespace, src.Name, src.Ip, src.Port))
+	}
+
+	if res.Destination != nil {
+		dst := res.Destination
+		sb.WriteString(fmt.Sprintf("Destination: %s/%s (%s:%d)\n", dst.Namespace, dst.Name, dst.Ip, dst.Port))
+	}
+
+	if res.Request != nil {
+		if res.Request.Method != "" {
+			sb.WriteString(fmt.Sprintf("Method: %s\n", res.Request.Method))
+		}
+		if res.Request.Path != "" {
+			sb.WriteString(fmt.Sprintf("Path: %s\n", res.Request.Path))
+		}
+		if res.Request.GrpcService != "" {
+			sb.WriteString(fmt.Sprintf("gRPC Service: %s\n", res.Request.GrpcService))
+		}
+		if res.Request.GrpcMethod != "" {
+			sb.WriteString(fmt.Sprintf("gRPC Method: %s\n", res.Request.GrpcMethod))
+		}
+	}
+
+	if res.Response != nil {
+		sb.WriteString(fmt.Sprintf("Status: %d\n", res.Response.StatusCode))
+		if res.Response.GrpcStatusCode != 0 {
+			sb.WriteString(fmt.Sprintf("gRPC Status: %d\n", res.Response.GrpcStatusCode))
+		}
+		if res.Response.GrpcStatusMessage != "" {
+			sb.WriteString(fmt.Sprintf("gRPC Message: %s\n", res.Response.GrpcStatusMessage))
+		}
+	}
+
+	if res.LatencyMs > 0 {
+		sb.WriteString(fmt.Sprintf("Latency: %dms\n", res.LatencyMs))
+	}
+
+	return sb.String()
+}
+
+// writeAPIEventOutput writes the formatted API event string to the configured output
+func writeAPIEventOutput(str string, o Options) {
+	if o.EventChan != nil {
+		arr, _ := json.Marshal(str)
+		o.EventChan <- EventInfo{Data: arr, Type: "APIEvent"}
+	}
+
+	if o.LogPath == "stdout" {
+		fmt.Printf("%s", str)
+	} else if o.LogPath != "" && o.LogPath != "none" {
 		StrToFile(str, o.LogPath)
 	}
 }


### PR DESCRIPTION
Added new logFilter `api` for streaming API events with karmor. 

Usage 
```
# Stream all API events
karmor logs --logFilter api

# Filter by namespace and protocol
karmor logs --logFilter api -n default --protocol HTTP

# Only show slow gRPC calls (>100ms) in JSON
karmor logs --logFilter api --protocol gRPC --minDuration 100 --json

# Limit to 10 events
karmor logs --logFilter api --limit 10
```

Added 4 new API Observer-specific filter fields:

1. Protocol — filter by protocol (HTTP, gRPC)
2. Method — filter by HTTP method (GET, POST, etc.)
3. StatusPattern — filter by status code pattern (2xx, 404, 5xx)
4. MinDurationMs — minimum latency threshold in milliseconds