### PR TITLE
fix(recommend): require trailing sep in sanitizeArchivePath prefix check

### DIFF
--- a/recommend/registry/registry.go
+++ b/recommend/registry/registry.go
@@ -194,8 +194,9 @@ func (r *Scanner) pullImage(imageName string) (err error) {
 
 // Sanitize archive file pathing from "G305: Zip Slip vulnerability"
 func sanitizeArchivePath(d, t string) (v string, err error) {
-	v = filepath.Join(d, t)
-	if strings.HasPrefix(v, filepath.Clean(d)) {
+	cleanD := filepath.Clean(d)
+	v = filepath.Join(cleanD, t)
+	if v == cleanD || strings.HasPrefix(v, cleanD+string(os.PathSeparator)) {
 		return v, nil
 	}
 


### PR DESCRIPTION
Closes https://github.com/kubearmor/kubearmor-client/issues/557

Removes prefix check edge case in `sanitizeArchivePath` by requiring the resolved path to either equal the trusted root or begin with the trusted root followed by a path separator. 

This prevents sibling paths sharing the same string prefix from bypassing the check, strengthening path validation as a defense-in-depth improvement. The practical impact is low because the extraction directory is created with `os.MkdirTemp`, making the directory name difficult to predict.
