### PR TITLE
Separate Management/Log PKI for unorchestrated mode

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -67,7 +67,7 @@ func init() {
 
 	logCmd.Flags().StringVar(&logOptions.GRPC, "gRPC", "", "gRPC server information")
 	logCmd.Flags().BoolVar(&logOptions.Secure, "secure", false, "connect to kubearmor on a secure connection")
-	logCmd.Flags().StringVar(&logOptions.TlsCertPath, "tlsCertPath", "/var/lib/kubearmor/tls", "path to the ca.crt, client.crt, and client.key if certs are provided locally")
+	logCmd.Flags().StringVar(&logOptions.TlsCertPath, "tlsCertPath", "/var/lib/kubearmor/tls", "path to the ca.crt, client.crt, and client.key if certs are provided locally (with split-plane PKI, the log plane at <path>/log is preferred automatically)")
 	logCmd.Flags().StringVar(&logOptions.TlsCertProvider, "tlsCertProvider", "self", "{self|external} self: dynamically crete client certificates, external: provide client certificate and key with --tlsCertPath")
 	logCmd.Flags().BoolVar(&logOptions.ReadCAFromSecret, "readCAFromSecret", true, "true if ca cert to be read from k8s secret on cluster running kubearmor")
 	logCmd.Flags().StringVar(&logOptions.MsgPath, "msgPath", "none", "Output location for messages, {path|stdout|none}")

--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -93,5 +93,6 @@ func init() {
 	vmPolicyCmd.AddCommand(vmPolicyDeleteCmd)
 
 	// gRPC endpoint flag to communicate with KubeArmor. Available across subcommands.
-	vmPolicyCmd.PersistentFlags().StringVar(&policyOptions.GRPC, "gRPC", "", "gRPC server information")
+	vmPolicyCmd.PersistentFlags().StringVar(&policyOptions.GRPC, "gRPC", "", "management gRPC server information (default localhost:32765, or KUBEARMOR_MANAGEMENT_SERVICE)")
+	vmPolicyCmd.PersistentFlags().StringVar(&policyOptions.ManagementTLSCertPath, "managementTLSCertPath", "", "management trust-plane directory holding ca.crt, client.crt and client.key (default /var/lib/kubearmor/tls/management, or KUBEARMOR_MANAGEMENT_TLS_CERT_PATH)")
 }

--- a/install/installUnochestrated.go
+++ b/install/installUnochestrated.go
@@ -124,6 +124,21 @@ func createDefaultConfigPath() (string, error) {
 	return configPath, nil
 }
 
+// SetupVMTLS generates the split-plane PKI (management + log CAs and karmor
+// client identities) used by unorchestrated deployments. An empty baseDir
+// selects DefaultVMTLSBaseDir. It is idempotent: existing key material is
+// never rotated, so re-running install is safe.
+func SetupVMTLS(baseDir string) error {
+	if baseDir == "" {
+		baseDir = DefaultVMTLSBaseDir
+	}
+	if err := EnsureVMPlanePKI(baseDir); err != nil {
+		return fmt.Errorf("failed to set up VM TLS PKI at %s: %w", baseDir, err)
+	}
+	fmt.Printf("🔐\tVM TLS PKI ready at %s (management/ and log/ trust planes)\n", baseDir)
+	return nil
+}
+
 func (config *KubeArmorConfig) DeployKAdocker() error {
 	_, err := config.ValidateEnv()
 	if err != nil {
@@ -132,6 +147,9 @@ func (config *KubeArmorConfig) DeployKAdocker() error {
 	fmt.Printf("ℹ️\tInstalling KubeArmor as a docker container")
 	configPath, err := createDefaultConfigPath()
 	if err != nil {
+		return err
+	}
+	if err := SetupVMTLS(""); err != nil {
 		return err
 	}
 	// initialize sprig for templating
@@ -317,6 +335,12 @@ func (config *KubeArmorConfig) SystemdInstall() error {
 	}
 
 	fmt.Printf("😄\tKubearmor service files placed successfully\n")
+
+	// Lay down the split-plane PKI before the service starts so the agent's
+	// SelfSignedCertLoader finds its per-plane CAs on first boot.
+	if err := SetupVMTLS(""); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/install/pki.go
+++ b/install/pki.go
@@ -8,7 +8,10 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/big"
+	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -118,4 +121,220 @@ func SignCSR(caCrt *x509.Certificate, caKey *rsa.PrivateKey, csrCrt *x509.Certif
 		return []byte{}, errors.New("cannot sign the csr")
 	}
 	return certBytes, nil
+}
+
+// Separate PKI for karmor unorchestrated (non-K8s) mode.
+//
+// The two trust domains are fully independent so that management and
+// observability credentials are never interchangeable:
+//
+//	base/
+//	  management/ca.crt, management/ca.key, management/client.crt, management/client.key
+//	  log/ca.crt,        log/ca.key,        log/client.crt,        log/client.key
+//
+// No server.crt/server.key is generated or persisted: KubeArmor's
+// SelfSignedCertLoader loads the respective CA and mints ephemeral server
+// certificates in memory at startup. File names intentionally match the
+// server-side layout (ca.crt/ca.key/client.crt/client.key, see
+// KubeArmor/cert GetCACertPath/GetClientCertPath).
+//
+// Generation reuses the existing primitives above:
+//   - GenerateCA() for the CA template + key (only the CommonName is
+//     overridden per plane),
+//   - SignCSR() for signing each plane's karmor client certificate,
+//   - the same PEM encoding ("CERTIFICATE" / "RSA PRIVATE KEY").
+//
+// GenerateCSR()/GeneratePki() are deliberately NOT reused: they are wired
+// for the K8s controller webhook (CN=kubearmor-webhook, webhook SANs) and
+// GeneratePki() additionally drops the CA key, which the server needs on
+// disk to mint its ephemeral server certificates.
+const (
+	// VMPlaneManagement is the management (policy/probe) trust domain.
+	VMPlaneManagement = "management"
+	// VMPlaneLog is the log/observability trust domain.
+	VMPlaneLog = "log"
+
+	// VMManagementCACommonName is the CommonName of the management CA.
+	VMManagementCACommonName = "kubearmor-management-ca"
+	// VMLogCACommonName is the CommonName of the log/observability CA.
+	VMLogCACommonName = "kubearmor-log-ca"
+
+	// VMManagementClientCommonName is the CommonName of the karmor management client cert.
+	VMManagementClientCommonName = "karmor-management-client"
+	// VMLogClientCommonName is the CommonName of the karmor log client cert.
+	VMLogClientCommonName = "karmor-log-client"
+
+	// DefaultVMTLSBaseDir is the default base directory holding the
+	// management/ and log/ plane subdirectories.
+	DefaultVMTLSBaseDir = "/var/lib/kubearmor/tls"
+
+	caCertFile     = "ca.crt"
+	caKeyFile      = "ca.key"
+	clientCertFile = "client.crt"
+	clientKeyFile  = "client.key"
+)
+
+// VMPlaneDir returns the directory holding a plane's PKI material.
+func VMPlaneDir(baseDir, plane string) string {
+	return filepath.Join(baseDir, plane)
+}
+
+// VMManagementDir returns the management plane directory.
+func VMManagementDir(baseDir string) string {
+	return VMPlaneDir(baseDir, VMPlaneManagement)
+}
+
+// VMLogDir returns the log/observability plane directory.
+func VMLogDir(baseDir string) string {
+	return VMPlaneDir(baseDir, VMPlaneLog)
+}
+
+// PlanePKI holds the PEM-encoded material for one trust plane.
+type PlanePKI struct {
+	CACert    *bytes.Buffer
+	CAKey     *bytes.Buffer
+	ClientCrt *bytes.Buffer
+	ClientKey *bytes.Buffer
+}
+
+// GeneratePlanePKI generates a dedicated CA plus a karmor client
+// certificate signed by that CA. It reuses GenerateCA() for the CA
+// template/key and SignCSR() for the client certificate signature.
+func GeneratePlanePKI(caCommonName, clientCommonName string) (*PlanePKI, error) {
+	caTmpl, caKey, err := GenerateCA()
+	if err != nil {
+		return nil, err
+	}
+	// Only the identity is plane-specific; key type/size/validity and
+	// key usages stay exactly as defined by GenerateCA().
+	caTmpl.Subject.CommonName = caCommonName
+
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		return nil, fmt.Errorf("cannot self-sign the %s ca: %w", caCommonName, err)
+	}
+	caCertPEM := new(bytes.Buffer)
+	if err := pem.Encode(caCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: caDER}); err != nil {
+		return nil, err
+	}
+	// Unlike GeneratePki() (webhook flow keeps the CA key inside the
+	// cluster signer), the unorchestrated server needs ca.key on disk:
+	// SelfSignedCertLoader reads it to mint ephemeral server certs.
+	caKeyPEM := new(bytes.Buffer)
+	if err := pem.Encode(caKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(caKey)}); err != nil {
+		return nil, err
+	}
+
+	clientTmpl := &x509.Certificate{
+		SerialNumber: newClientSerial(),
+		Subject: pkix.Name{
+			Organization: []string{"kubearmor"},
+			Country:      []string{"US"},
+			CommonName:   clientCommonName,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0), // valid for 1 year
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	clientKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, fmt.Errorf("cannot generate %s private key: %w", clientCommonName, err)
+	}
+	clientDER, err := SignCSR(caTmpl, caKey, clientTmpl, clientKey)
+	if err != nil {
+		return nil, err
+	}
+	clientCrtPEM := new(bytes.Buffer)
+	if err := pem.Encode(clientCrtPEM, &pem.Block{Type: "CERTIFICATE", Bytes: clientDER}); err != nil {
+		return nil, err
+	}
+	clientKeyPEM := new(bytes.Buffer)
+	if err := pem.Encode(clientKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)}); err != nil {
+		return nil, err
+	}
+
+	return &PlanePKI{
+		CACert:    caCertPEM,
+		CAKey:     caKeyPEM,
+		ClientCrt: clientCrtPEM,
+		ClientKey: clientKeyPEM,
+	}, nil
+}
+
+func newClientSerial() *big.Int {
+	// 128-bit random serial (RFC 5280: positive, <= 20 octets). The legacy
+	// webhook helpers use fixed serials; random serials are safe here and
+	// avoid any cross-plane collision.
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return big.NewInt(1)
+	}
+	return serial
+}
+
+// planeComplete reports whether all four plane files already exist.
+// server.crt/server.key are intentionally absent (see package doc).
+func planeComplete(dir string) bool {
+	for _, f := range []string{caCertFile, caKeyFile, clientCertFile, clientKeyFile} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// writePlaneFile writes data to dir/file with 0600 unless it already exists.
+func writePlaneFile(dir, file string, data *bytes.Buffer) error {
+	path := filepath.Join(dir, file)
+	if _, err := os.Stat(path); err == nil {
+		return nil // never clobber existing key material
+	}
+	return os.WriteFile(path, data.Bytes(), 0600)
+}
+
+// ensurePlane generates (via GeneratePlanePKI) and persists one plane,
+// skipping planes whose four files already exist.
+func ensurePlane(baseDir, plane, caCN, clientCN string) error {
+	dir := VMPlaneDir(baseDir, plane)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return err
+	}
+	if planeComplete(dir) {
+		return nil
+	}
+	pki, err := GeneratePlanePKI(caCN, clientCN)
+	if err != nil {
+		return err
+	}
+	if err := writePlaneFile(dir, caCertFile, pki.CACert); err != nil {
+		return err
+	}
+	if err := writePlaneFile(dir, caKeyFile, pki.CAKey); err != nil {
+		return err
+	}
+	if err := writePlaneFile(dir, clientCertFile, pki.ClientCrt); err != nil {
+		return err
+	}
+	if err := writePlaneFile(dir, clientKeyFile, pki.ClientKey); err != nil {
+		return err
+	}
+	return nil
+}
+
+// EnsureVMPlanePKI generates and persists both trust planes under baseDir.
+// It is idempotent: planes whose ca.crt/ca.key/client.crt/client.key all
+// exist are left untouched, so existing keys are never rotated by re-run.
+func EnsureVMPlanePKI(baseDir string) error {
+	if baseDir == "" {
+		baseDir = DefaultVMTLSBaseDir
+	}
+	if err := ensurePlane(baseDir, VMPlaneManagement, VMManagementCACommonName, VMManagementClientCommonName); err != nil {
+		return fmt.Errorf("cannot ensure management plane PKI: %w", err)
+	}
+	if err := ensurePlane(baseDir, VMPlaneLog, VMLogCACommonName, VMLogClientCommonName); err != nil {
+		return fmt.Errorf("cannot ensure log plane PKI: %w", err)
+	}
+	return nil
 }

--- a/install/pki_test.go
+++ b/install/pki_test.go
@@ -1,0 +1,240 @@
+package install
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func parseTestCert(t *testing.T, pemBytes []byte) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		t.Fatal("failed to decode PEM block")
+	}
+	crt, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	return crt
+}
+
+func TestGeneratePlanePKI_CommonNames(t *testing.T) {
+	mgmt, err := GeneratePlanePKI(VMManagementCACommonName, VMManagementClientCommonName)
+	if err != nil {
+		t.Fatalf("GeneratePlanePKI management failed: %v", err)
+	}
+	logPKI, err := GeneratePlanePKI(VMLogCACommonName, VMLogClientCommonName)
+	if err != nil {
+		t.Fatalf("GeneratePlanePKI log failed: %v", err)
+	}
+
+	mgmtCA := parseTestCert(t, mgmt.CACert.Bytes())
+	if mgmtCA.Subject.CommonName != VMManagementCACommonName {
+		t.Errorf("management CA CN = %q, want %q", mgmtCA.Subject.CommonName, VMManagementCACommonName)
+	}
+	if !mgmtCA.IsCA {
+		t.Error("management CA IsCA = false, want true")
+	}
+	logCA := parseTestCert(t, logPKI.CACert.Bytes())
+	if logCA.Subject.CommonName != VMLogCACommonName {
+		t.Errorf("log CA CN = %q, want %q", logCA.Subject.CommonName, VMLogCACommonName)
+	}
+
+	mgmtClient := parseTestCert(t, mgmt.ClientCrt.Bytes())
+	if mgmtClient.Subject.CommonName != VMManagementClientCommonName {
+		t.Errorf("management client CN = %q, want %q", mgmtClient.Subject.CommonName, VMManagementClientCommonName)
+	}
+	if mgmtClient.IsCA {
+		t.Error("management client IsCA = true, want false")
+	}
+	hasClientAuth := false
+	for _, eku := range mgmtClient.ExtKeyUsage {
+		if eku == x509.ExtKeyUsageClientAuth {
+			hasClientAuth = true
+		}
+		if eku == x509.ExtKeyUsageServerAuth {
+			t.Error("client cert must not have ServerAuth EKU")
+		}
+	}
+	if !hasClientAuth {
+		t.Error("client cert missing ClientAuth EKU")
+	}
+}
+
+func TestGeneratePlanePKI_CAsAreDistinct(t *testing.T) {
+	mgmt, err := GeneratePlanePKI(VMManagementCACommonName, VMManagementClientCommonName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logPKI, err := GeneratePlanePKI(VMLogCACommonName, VMLogClientCommonName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mgmtCA := parseTestCert(t, mgmt.CACert.Bytes())
+	logCA := parseTestCert(t, logPKI.CACert.Bytes())
+	if string(mgmtCA.RawSubject) == string(logCA.RawSubject) {
+		t.Error("management and log CAs share the same subject, want distinct trust roots")
+	}
+	mgmtPub, err := x509.MarshalPKIXPublicKey(mgmtCA.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logPub, err := x509.MarshalPKIXPublicKey(logCA.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(mgmtPub) == string(logPub) {
+		t.Error("management and log CAs share the same public key, want distinct trust roots")
+	}
+}
+
+func verifyClientAgainstCA(t *testing.T, clientPEM, caPEM []byte) error {
+	t.Helper()
+	client := parseTestCert(t, clientPEM)
+	ca := parseTestCert(t, caPEM)
+	pool := x509.NewCertPool()
+	pool.AddCert(ca)
+	_, err := client.Verify(x509.VerifyOptions{Roots: pool, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}})
+	return err
+}
+
+func TestGeneratePlanePKI_ClientsAreNotInterchangeable(t *testing.T) {
+	mgmt, err := GeneratePlanePKI(VMManagementCACommonName, VMManagementClientCommonName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logPKI, err := GeneratePlanePKI(VMLogCACommonName, VMLogClientCommonName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Each client verifies against its own CA.
+	if err := verifyClientAgainstCA(t, mgmt.ClientCrt.Bytes(), mgmt.CACert.Bytes()); err != nil {
+		t.Errorf("management client does not verify against management CA: %v", err)
+	}
+	if err := verifyClientAgainstCA(t, logPKI.ClientCrt.Bytes(), logPKI.CACert.Bytes()); err != nil {
+		t.Errorf("log client does not verify against log CA: %v", err)
+	}
+	// Cross-plane verification must fail.
+	if err := verifyClientAgainstCA(t, mgmt.ClientCrt.Bytes(), logPKI.CACert.Bytes()); err == nil {
+		t.Error("management client verified against log CA, want failure (planes must not be interchangeable)")
+	}
+	if err := verifyClientAgainstCA(t, logPKI.ClientCrt.Bytes(), mgmt.CACert.Bytes()); err == nil {
+		t.Error("log client verified against management CA, want failure (planes must not be interchangeable)")
+	}
+}
+
+func TestSetupVMTLS_CreatesBothPlanes(t *testing.T) {
+	base := t.TempDir()
+	if err := SetupVMTLS(base); err != nil {
+		t.Fatalf("SetupVMTLS failed: %v", err)
+	}
+	for _, plane := range []string{VMPlaneManagement, VMPlaneLog} {
+		for _, f := range []string{caCertFile, caKeyFile, clientCertFile, clientKeyFile} {
+			if _, err := os.Stat(filepath.Join(VMPlaneDir(base, plane), f)); err != nil {
+				t.Errorf("plane %s: expected file %s: %v", plane, f, err)
+			}
+		}
+	}
+	// Re-run must preserve existing key material (idempotent install).
+	snap, err := os.ReadFile(filepath.Join(VMManagementDir(base), caCertFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SetupVMTLS(base); err != nil {
+		t.Fatal(err)
+	}
+	again, err := os.ReadFile(filepath.Join(VMManagementDir(base), caCertFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(snap) != string(again) {
+		t.Error("SetupVMTLS re-run rotated the management CA, want existing key material preserved")
+	}
+}
+
+func TestEnsureVMPlanePKI_Layout(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureVMPlanePKI(base); err != nil {
+		t.Fatalf("EnsureVMPlanePKI failed: %v", err)
+	}
+	for _, plane := range []string{VMPlaneManagement, VMPlaneLog} {
+		dir := VMPlaneDir(base, plane)
+		for _, f := range []string{caCertFile, caKeyFile, clientCertFile, clientKeyFile} {
+			info, err := os.Stat(filepath.Join(dir, f))
+			if err != nil {
+				t.Errorf("plane %s: expected file %s: %v", plane, f, err)
+				continue
+			}
+			if info.Mode().Perm() != 0600 {
+				t.Errorf("plane %s file %s perm = %o, want 600", plane, f, info.Mode().Perm())
+			}
+			if info.Size() == 0 {
+				t.Errorf("plane %s file %s is empty", plane, f)
+			}
+		}
+		// No persisted server key material.
+		for _, f := range []string{"server.crt", "server.key"} {
+			if _, err := os.Stat(filepath.Join(dir, f)); !os.IsNotExist(err) {
+				t.Errorf("plane %s: %s must not be persisted", plane, f)
+			}
+		}
+	}
+}
+
+func TestEnsureVMPlanePKI_Idempotent(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureVMPlanePKI(base); err != nil {
+		t.Fatal(err)
+	}
+	before := map[string][]byte{}
+	for _, plane := range []string{VMPlaneManagement, VMPlaneLog} {
+		for _, f := range []string{caCertFile, caKeyFile, clientCertFile, clientKeyFile} {
+			b, err := os.ReadFile(filepath.Join(VMPlaneDir(base, plane), f))
+			if err != nil {
+				t.Fatal(err)
+			}
+			before[plane+"/"+f] = b
+		}
+	}
+	if err := EnsureVMPlanePKI(base); err != nil {
+		t.Fatal(err)
+	}
+	for k, b := range before {
+		after, err := os.ReadFile(filepath.Join(base, k))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(after) != string(b) {
+			t.Errorf("re-run rotated %s, want existing key material preserved", k)
+		}
+	}
+}
+
+func TestEnsureVMPlanePKI_OnDiskClientsVerify(t *testing.T) {
+	base := t.TempDir()
+	if err := EnsureVMPlanePKI(base); err != nil {
+		t.Fatal(err)
+	}
+	read := func(plane, f string) []byte {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join(VMPlaneDir(base, plane), f))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return b
+	}
+	mgmtCrt, mgmtCA := read(VMPlaneManagement, clientCertFile), read(VMPlaneManagement, caCertFile)
+	logCrt, logCA := read(VMPlaneLog, clientCertFile), read(VMPlaneLog, caCertFile)
+	if err := verifyClientAgainstCA(t, mgmtCrt, mgmtCA); err != nil {
+		t.Errorf("on-disk management client does not verify: %v", err)
+	}
+	if err := verifyClientAgainstCA(t, logCrt, logCA); err != nil {
+		t.Errorf("on-disk log client does not verify: %v", err)
+	}
+	if err := verifyClientAgainstCA(t, mgmtCrt, logCA); err == nil {
+		t.Error("on-disk management client verified against log CA, want failure")
+	}
+}

--- a/install/pki_test.go
+++ b/install/pki_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/pem"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -152,6 +153,35 @@ func TestSetupVMTLS_CreatesBothPlanes(t *testing.T) {
 	}
 	if string(snap) != string(again) {
 		t.Error("SetupVMTLS re-run rotated the management CA, want existing key material preserved")
+	}
+}
+
+// The agent must be pointed at the split-plane PKI: the systemd unit and
+// the docker-compose template pass both TLS flags, the agent config
+// template carries both TLS keys, and the compose template mounts the TLS
+// base directory into the agent container.
+func TestUnorchestratedTemplatesCarrySplitPlaneTLS(t *testing.T) {
+	for _, flag := range []string{
+		"-tlsCertPath=/var/lib/kubearmor/tls/log",
+		"-managementTLSCertPath=/var/lib/kubearmor/tls/management",
+	} {
+		if !strings.Contains(kubearmorServiceFile, flag) {
+			t.Errorf("kubearmor.service missing %q", flag)
+		}
+		if !strings.Contains(kubearmorcomposeTemplate, flag) {
+			t.Errorf("compose template missing %q", flag)
+		}
+	}
+	for _, key := range []string{
+		"tlsCertPath: /var/lib/kubearmor/tls/log",
+		"managementTLSCertPath: /var/lib/kubearmor/tls/management",
+	} {
+		if !strings.Contains(kubeArmorConfig, key) {
+			t.Errorf("config template missing %q", key)
+		}
+	}
+	if !strings.Contains(kubearmorcomposeTemplate, "/var/lib/kubearmor/tls:/var/lib/kubearmor/tls:ro") {
+		t.Error("compose template missing read-only TLS volume mount")
 	}
 }
 

--- a/install/pki_test.go
+++ b/install/pki_test.go
@@ -1,12 +1,17 @@
 package install
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"text/template"
+
+	"github.com/Masterminds/sprig"
+	"sigs.k8s.io/yaml"
 )
 
 func parseTestCert(t *testing.T, pemBytes []byte) *x509.Certificate {
@@ -182,6 +187,114 @@ func TestUnorchestratedTemplatesCarrySplitPlaneTLS(t *testing.T) {
 	}
 	if !strings.Contains(kubearmorcomposeTemplate, "/var/lib/kubearmor/tls:/var/lib/kubearmor/tls:ro") {
 		t.Error("compose template missing read-only TLS volume mount")
+	}
+}
+
+func sampleUnorchestratedConfig() *KubeArmorConfig {
+	return &KubeArmorConfig{
+		Hostname:                    "test-host",
+		KubeArmorImage:              "kubearmor/kubearmor:test",
+		KubeArmorInitImage:          "kubearmor/kubearmor-init:test",
+		ImagePullPolicy:             "always",
+		KubeArmorVisibility:         "process,network",
+		KubeArmorHostVisibility:     "process,network",
+		KubeArmorFilePosture:        "block",
+		KubeArmorNetworkPosture:     "block",
+		KubeArmorCapPosture:         "block",
+		KubeArmorHostFilePosture:    "block",
+		KubeArmorHostNetworkPosture: "block",
+		KubeArmorHostCapPosture:     "block",
+		KubeArmorAlertThrottling:    true,
+		KubeArmorMaxAlertsPerSec:    10,
+		KubeArmorThrottleSec:        30,
+		KubeArmorPort:               "32767",
+		SecureContainers:            false,
+	}
+}
+
+func renderTemplate(t *testing.T, name, tmpl string, data *KubeArmorConfig) map[string]interface{} {
+	t.Helper()
+	var buf bytes.Buffer
+	tpl, err := template.New(name).Funcs(sprig.GenericFuncMap()).Parse(tmpl)
+	if err != nil {
+		t.Fatalf("template %s does not parse: %v", name, err)
+	}
+	if err := tpl.Execute(&buf, data); err != nil {
+		t.Fatalf("template %s does not render: %v", name, err)
+	}
+	var out map[string]interface{}
+	if err := yaml.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("rendered %s is not valid YAML: %v", name, err)
+	}
+	return out
+}
+
+func strSlice(t *testing.T, v interface{}) []string {
+	t.Helper()
+	raw, ok := v.([]interface{})
+	if !ok {
+		t.Fatalf("expected a YAML list, got %T", v)
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		s, ok := item.(string)
+		if !ok {
+			t.Fatalf("expected list of strings, got %T", item)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// Render-level smoke test for the agent side: the compose and agent-config
+// templates must render to valid YAML carrying the split-plane TLS wiring
+// the agent needs to serve mTLS from the generated PKI layout.
+func TestUnorchestratedTemplatesRenderSplitPlaneTLS(t *testing.T) {
+	cfg := sampleUnorchestratedConfig()
+
+	compose := renderTemplate(t, "compose", kubearmorcomposeTemplate, cfg)
+	svcs, ok := compose["services"].(map[string]interface{})
+	if !ok {
+		t.Fatal("rendered compose has no services map")
+	}
+	agent, ok := svcs["kubearmor"].(map[string]interface{})
+	if !ok {
+		t.Fatal("rendered compose has no kubearmor service")
+	}
+	cmd := strSlice(t, agent["command"])
+	for _, want := range []string{
+		"-tlsCertPath=/var/lib/kubearmor/tls/log",
+		"-managementTLSCertPath=/var/lib/kubearmor/tls/management",
+	} {
+		found := false
+		for _, arg := range cmd {
+			if arg == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("rendered compose command missing %q (got %v)", want, cmd)
+		}
+	}
+	vols := strSlice(t, agent["volumes"])
+	found := false
+	for _, v := range vols {
+		if v == "/var/lib/kubearmor/tls:/var/lib/kubearmor/tls:ro" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("rendered compose volumes missing read-only TLS mount (got %v)", vols)
+	}
+
+	agentCfg := renderTemplate(t, "kubearmor-config", kubeArmorConfig, cfg)
+	if agentCfg["tlsCertPath"] != "/var/lib/kubearmor/tls/log" {
+		t.Errorf("rendered agent config tlsCertPath = %v", agentCfg["tlsCertPath"])
+	}
+	if agentCfg["managementTLSCertPath"] != "/var/lib/kubearmor/tls/management" {
+		t.Errorf("rendered agent config managementTLSCertPath = %v", agentCfg["managementTLSCertPath"])
 	}
 }
 

--- a/install/templates/composeTemplate.yaml
+++ b/install/templates/composeTemplate.yaml
@@ -49,10 +49,13 @@ services:
       - "-alertThrottling={{.KubeArmorAlertThrottling}}"
       - "-maxAlertPerSec={{.KubeArmorMaxAlertsPerSec}}"
       - "-throttleSec={{.KubeArmorThrottleSec}}"
+      - "-tlsCertPath=/var/lib/kubearmor/tls/log"
+      - "-managementTLSCertPath=/var/lib/kubearmor/tls/management"
     labels:
       app: kubearmor
     volumes:
       - "kubearmor-init-vol:/opt/kubearmor/BPF"
+      - "/var/lib/kubearmor/tls:/var/lib/kubearmor/tls:ro"
       - "/sys/fs/bpf:/sys/fs/bpf"
       - "/sys/kernel/security:/sys/kernel/security"
       - "/sys/kernel/debug:/sys/kernel/debug"

--- a/install/templates/configTemplate.yaml
+++ b/install/templates/configTemplate.yaml
@@ -25,3 +25,7 @@ hostDefaultCapabilitiesPosture: {{.KubeArmorHostCapPosture}}
 alertThrottling: {{.KubeArmorAlertThrottling}}
 maxAlertPerSec: {{.KubeArmorMaxAlertsPerSec}}
 throttleSec: {{.KubeArmorThrottleSec}}
+
+# tls settings (split-plane PKI provisioned by karmor install)
+tlsCertPath: /var/lib/kubearmor/tls/log
+managementTLSCertPath: /var/lib/kubearmor/tls/management

--- a/install/templates/kubearmor.service
+++ b/install/templates/kubearmor.service
@@ -5,7 +5,7 @@ Description=KubeArmor
 User=root
 KillMode=process
 WorkingDirectory=/opt/kubearmor/
-ExecStart=/opt/kubearmor/kubearmor
+ExecStart=/opt/kubearmor/kubearmor -tlsCertPath=/var/lib/kubearmor/tls/log -managementTLSCertPath=/var/lib/kubearmor/tls/management
 Restart=always
 RestartSec=10
 

--- a/log/plane.go
+++ b/log/plane.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package log
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// LogPlaneSubdir is the log/observability trust-plane subdirectory under a
+// split-PKI base directory (<base>/log/ca.crt, ...).
+const LogPlaneSubdir = "log"
+
+// LogPlaneCACertFile is the file probed to detect a split-PKI layout.
+const LogPlaneCACertFile = "ca.crt"
+
+// ResolveLogCertPath maps a configured TLS base to the log trust plane:
+// when <base>/log/ca.crt exists (split PKI from karmor unorchestrated
+// setup), the log plane directory is used so log commands authenticate
+// with the Log CA + log client identity; otherwise the configured path is
+// returned unchanged for backward compatibility with single-CA layouts.
+func ResolveLogCertPath(configured string) string {
+	if configured == "" {
+		return configured
+	}
+	if _, err := os.Stat(filepath.Join(configured, LogPlaneSubdir, LogPlaneCACertFile)); err == nil {
+		return filepath.Join(configured, LogPlaneSubdir)
+	}
+	return configured
+}

--- a/log/plane_test.go
+++ b/log/plane_test.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveLogCertPathEmpty(t *testing.T) {
+	if got := ResolveLogCertPath(""); got != "" {
+		t.Errorf("empty input = %q, want empty", got)
+	}
+}
+
+func TestResolveLogCertPathSingleCA(t *testing.T) {
+	base := t.TempDir()
+	// Legacy single-CA layout: ca.crt directly under base, no log/ subdir.
+	if err := os.WriteFile(filepath.Join(base, "ca.crt"), []byte("dummy"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ResolveLogCertPath(base); got != base {
+		t.Errorf("single-CA layout resolved to %q, want %q", got, base)
+	}
+}
+
+func TestResolveLogCertPathSplitPKI(t *testing.T) {
+	base := t.TempDir()
+	logDir := filepath.Join(base, LogPlaneSubdir)
+	if err := os.MkdirAll(logDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logDir, LogPlaneCACertFile), []byte("dummy"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(base, LogPlaneSubdir)
+	if got := ResolveLogCertPath(base); got != want {
+		t.Errorf("split-PKI layout resolved to %q, want %q", got, want)
+	}
+}

--- a/log/tls.go
+++ b/log/tls.go
@@ -29,15 +29,20 @@ func loadTLSCredentials(client kubernetes.Interface, o Options) (credentials.Tra
 		clientCertCfg = cert.DefaultKubeArmorClientConfig
 		clientCertCfg.NotAfter = time.Now().AddDate(1, 0, 0) // valid for 1 year
 	}
+	// Resolve the log trust plane: with a split-PKI layout
+	// (<base>/log/ca.crt present) log commands use the Log CA + log
+	// client identity; otherwise fall back to the configured path
+	// (single-CA layouts).
+	logCertPath := ResolveLogCertPath(o.TlsCertPath)
 	tlsConfig := cert.TlsConfig{
 		CertCfg:              clientCertCfg,
 		ReadCACertFromSecret: o.ReadCAFromSecret,
 		SecretName:           secret,
 		Namespace:            namespace,
 		K8sClient:            client.(*kubernetes.Clientset),
-		CertPath:             cert.GetClientCertPath(o.TlsCertPath),
+		CertPath:             cert.GetClientCertPath(logCertPath),
 		CertProvider:         o.TlsCertProvider,
-		CACertPath:           cert.GetCACertPath(o.TlsCertPath),
+		CACertPath:           cert.GetCACertPath(logCertPath),
 	}
 	creds, err := cert.NewTlsCredentialManager(&tlsConfig).CreateTlsClientCredentials()
 	if err != nil {

--- a/vm/policy.go
+++ b/vm/policy.go
@@ -15,8 +15,6 @@ import (
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 	pb "github.com/kubearmor/KubeArmor/protobuf"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"sigs.k8s.io/yaml"
 )
 
@@ -32,29 +30,29 @@ const (
 // PolicyOptions are optional configuration for kArmor vm policy
 type PolicyOptions struct {
 	GRPC string
+	// ManagementTLSCertPath is the management trust-plane directory
+	// (management/ca.crt + management/client.crt/client.key). Empty means
+	// resolve via KUBEARMOR_MANAGEMENT_TLS_CERT_PATH or the default.
+	ManagementTLSCertPath string
 }
 
 func sendPolicyOverGRPC(o PolicyOptions, policyEventData []byte, kind string) error {
 	var (
-		gRPC = ""
 		resp *pb.Response
 		err  error
 	)
 
-	if o.GRPC != "" {
-		gRPC = o.GRPC
-	} else {
-		if val, ok := os.LookupEnv("KUBEARMOR_SERVICE"); ok {
-			gRPC = val
-		} else {
-			gRPC = "localhost:32767"
-		}
-	}
+	// PolicyService lives on the management plane; always use the
+	// management CA + client identity, never the log-plane credentials
+	// and never an insecure channel.
+	gRPC := ManagementGRPCAddress(o.GRPC)
+	mgmtDir := ManagementTLSCertPath(o.ManagementTLSCertPath)
 
-	conn, err := grpc.NewClient(gRPC, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := NewManagementGRPCClient(gRPC, mgmtDir)
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 
 	client := pb.NewPolicyServiceClient(conn)
 

--- a/vm/policy.go
+++ b/vm/policy.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -15,6 +16,10 @@ import (
 	tp "github.com/kubearmor/KubeArmor/KubeArmor/types"
 	pb "github.com/kubearmor/KubeArmor/protobuf"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"sigs.k8s.io/yaml"
 )
 
@@ -36,43 +41,82 @@ type PolicyOptions struct {
 	ManagementTLSCertPath string
 }
 
-func sendPolicyOverGRPC(o PolicyOptions, policyEventData []byte, kind string) error {
-	var (
-		resp *pb.Response
-		err  error
-	)
+func isManagementUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "connection refused") || strings.Contains(msg, "connection closed") {
+		return true
+	}
+	if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
+		return true
+	}
+	return false
+}
 
-	// PolicyService lives on the management plane; always use the
-	// management CA + client identity, never the log-plane credentials
-	// and never an insecure channel.
+func doPolicyRPC(client pb.PolicyServiceClient, kind string, data []byte) (*pb.Response, error) {
+	req := pb.Policy{Policy: data}
+	switch kind {
+	case KubeArmorPolicy:
+		return client.ContainerPolicy(context.Background(), &req)
+	case KubeArmorHostPolicy:
+		return client.HostPolicy(context.Background(), &req)
+	case KubeArmorNetworkPolicy:
+		return client.NetworkPolicy(context.Background(), &req)
+	default:
+		return nil, fmt.Errorf("unknown policy kind %q", kind)
+	}
+}
+
+func sendPolicyOverGRPC(o PolicyOptions, policyEventData []byte, kind string) error {
+	// Primary path: management plane on :32765 with mTLS.
 	gRPC := ManagementGRPCAddress(o.GRPC)
 	mgmtDir := ManagementTLSCertPath(o.ManagementTLSCertPath)
 
 	conn, err := NewManagementGRPCClient(gRPC, mgmtDir)
 	if err != nil {
+		if isManagementUnavailable(err) {
+			return sendPolicyOverGRPCFallback(gRPC, policyEventData, kind)
+		}
 		return err
 	}
 	defer conn.Close()
 
-	client := pb.NewPolicyServiceClient(conn)
-
-	req := pb.Policy{
-		Policy: policyEventData,
-	}
-
-	switch kind {
-	case KubeArmorPolicy:
-		resp, err = client.ContainerPolicy(context.Background(), &req)
-	case KubeArmorHostPolicy:
-		resp, err = client.HostPolicy(context.Background(), &req)
-	case KubeArmorNetworkPolicy:
-		resp, err = client.NetworkPolicy(context.Background(), &req)
-	}
-
+	resp, err := doPolicyRPC(pb.NewPolicyServiceClient(conn), kind, policyEventData)
 	if err != nil {
+		if isManagementUnavailable(err) {
+			return sendPolicyOverGRPCFallback(gRPC, policyEventData, kind)
+		}
 		return fmt.Errorf("failed to send policy")
 	}
 
+	fmt.Printf("Policy %s \n", resp.Status)
+	return nil
+}
+
+// sendPolicyOverGRPCFallback is the pre-split-plane path: PolicyService on
+// :32767 (log plane port) over an insecure channel. Used when the agent is
+// an older KubeArmor that does not serve the management plane on :32765.
+func sendPolicyOverGRPCFallback(primaryAddr string, policyEventData []byte, kind string) error {
+	legacyAddr := "localhost:32767"
+	if host, _, err := net.SplitHostPort(primaryAddr); err == nil && host != "" {
+		legacyAddr = net.JoinHostPort(host, "32767")
+	} else if val, ok := os.LookupEnv("KUBEARMOR_SERVICE"); ok && val != "" {
+		if host, _, err := net.SplitHostPort(val); err == nil && host != "" {
+			legacyAddr = net.JoinHostPort(host, "32767")
+		}
+	}
+	conn, err := grpc.NewClient(legacyAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	resp, err := doPolicyRPC(pb.NewPolicyServiceClient(conn), kind, policyEventData)
+	if err != nil {
+		return fmt.Errorf("failed to send policy")
+	}
 	fmt.Printf("Policy %s \n", resp.Status)
 	return nil
 }

--- a/vm/tls.go
+++ b/vm/tls.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package vm
+
+import (
+	"os"
+
+	"github.com/kubearmor/KubeArmor/KubeArmor/cert"
+	"github.com/kubearmor/kubearmor-client/install"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// DefaultManagementTLSCertPath is the default management trust-plane
+// directory (management/ca.crt + management/client.crt/client.key).
+// It mirrors the server default {tlsCertPath}/management so karmor and a
+// local KubeArmor agent agree out of the box.
+const DefaultManagementTLSCertPath = "/var/lib/kubearmor/tls/management"
+
+// DefaultManagementGRPCAddress is the default management-plane endpoint.
+// PolicyService/ProbeService live on the management server (32765), not on
+// the observability log server (32767).
+const DefaultManagementGRPCAddress = "localhost:32765"
+
+// ManagementTLSCertPath resolves the management plane directory:
+// explicit flag value wins, then KUBEARMOR_MANAGEMENT_TLS_CERT_PATH,
+// then the compiled-in default.
+func ManagementTLSCertPath(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	if val, ok := os.LookupEnv("KUBEARMOR_MANAGEMENT_TLS_CERT_PATH"); ok && val != "" {
+		return val
+	}
+	return DefaultManagementTLSCertPath
+}
+
+// ManagementPlaneDir maps a split-PKI base directory
+// (<base>/management, <base>/log) to its management plane directory.
+func ManagementPlaneDir(baseDir string) string {
+	return install.VMManagementDir(baseDir)
+}
+
+// ManagementGRPCAddress resolves the management-plane endpoint:
+// explicit flag value wins, then KUBEARMOR_MANAGEMENT_SERVICE,
+// then the compiled-in default.
+func ManagementGRPCAddress(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	if val, ok := os.LookupEnv("KUBEARMOR_MANAGEMENT_SERVICE"); ok && val != "" {
+		return val
+	}
+	return DefaultManagementGRPCAddress
+}
+
+// ManagementClientCredentials builds mutual-TLS client credentials from the
+// management plane's persisted material (ca.crt + client.crt/client.key).
+// The management CA is the only trust root, so log-plane identities can
+// never authenticate here and vice versa.
+func ManagementClientCredentials(mgmtDir string) (credentials.TransportCredentials, error) {
+	tlsConfig := cert.TlsConfig{
+		CertProvider: cert.ExternalCertProvider,
+		CACertPath:   cert.GetCACertPath(mgmtDir),
+		CertPath:     cert.GetClientCertPath(mgmtDir),
+	}
+	return cert.NewTlsCredentialManager(&tlsConfig).CreateTlsClientCredentials()
+}
+
+// NewManagementGRPCClient dials the management plane with mutual TLS.
+func NewManagementGRPCClient(address, mgmtDir string) (*grpc.ClientConn, error) {
+	creds, err := ManagementClientCredentials(mgmtDir)
+	if err != nil {
+		return nil, err
+	}
+	return grpc.NewClient(address, grpc.WithTransportCredentials(creds))
+}

--- a/vm/tls_test.go
+++ b/vm/tls_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Authors of KubeArmor
+
+package vm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubearmor/kubearmor-client/install"
+)
+
+func TestManagementTLSCertPathResolution(t *testing.T) {
+	if got := ManagementTLSCertPath("/custom/mgmt"); got != "/custom/mgmt" {
+		t.Errorf("explicit path = %q, want /custom/mgmt", got)
+	}
+	t.Setenv("KUBEARMOR_MANAGEMENT_TLS_CERT_PATH", "/env/mgmt")
+	if got := ManagementTLSCertPath(""); got != "/env/mgmt" {
+		t.Errorf("env path = %q, want /env/mgmt", got)
+	}
+	os.Unsetenv("KUBEARMOR_MANAGEMENT_TLS_CERT_PATH")
+	if got := ManagementTLSCertPath(""); got != DefaultManagementTLSCertPath {
+		t.Errorf("default path = %q, want %q", got, DefaultManagementTLSCertPath)
+	}
+}
+
+func TestManagementGRPCAddressResolution(t *testing.T) {
+	if got := ManagementGRPCAddress("host:1"); got != "host:1" {
+		t.Errorf("explicit addr = %q, want host:1", got)
+	}
+	t.Setenv("KUBEARMOR_MANAGEMENT_SERVICE", "host:2")
+	if got := ManagementGRPCAddress(""); got != "host:2" {
+		t.Errorf("env addr = %q, want host:2", got)
+	}
+	os.Unsetenv("KUBEARMOR_MANAGEMENT_SERVICE")
+	if got := ManagementGRPCAddress(""); got != DefaultManagementGRPCAddress {
+		t.Errorf("default addr = %q, want %q", got, DefaultManagementGRPCAddress)
+	}
+	if got := ManagementGRPCAddress(""); got == "localhost:32767" {
+		t.Error("management default must not be the observability port 32767")
+	}
+}
+
+func TestManagementClientCredentialsUsesManagementPlane(t *testing.T) {
+	base := t.TempDir()
+	if err := install.EnsureVMPlanePKI(base); err != nil {
+		t.Fatal(err)
+	}
+	mgmtDir := install.VMManagementDir(base)
+
+	creds, err := ManagementClientCredentials(mgmtDir)
+	if err != nil {
+		t.Fatalf("ManagementClientCredentials failed on management plane dir: %v", err)
+	}
+	if creds == nil {
+		t.Fatal("expected non-nil transport credentials")
+	}
+
+	// A missing plane directory must fail fast instead of silently
+	// falling back to another trust domain.
+	if _, err := ManagementClientCredentials(filepath.Join(base, "does-not-exist")); err == nil {
+		t.Error("expected error for missing management plane dir, got nil")
+	}
+}


### PR DESCRIPTION
Generate two independent trust planes (management + log), each with its own CA and karmor client identity, reusing the existing GenerateCA and SignCSR helpers from install/pki.go. Server certificates stay ephemeral via the server SelfSignedCertLoader; only ca.crt/ca.key and client.crt/client.key are persisted per plane.

Wire credential selection: vm policy commands use the management plane over mTLS (default localhost:32765), log commands prefer the log plane directory with single-CA fallback. Hook PKI generation into karmor install --nonk8s (docker + systemd) via SetupVMTLS.

```

                              karmor vm init
                                    │
                  ┌─────────────────┴─────────────────┐
                  │                                   │
                  ▼                                   ▼
          MANAGEMENT CA                         LOG CA
          ca.cert + ca.key                      ca.cert + ca.key
                  │                                   │
          ┌───────┴───────┐                   ┌───────┴───────┐
          │               │                   │               │
          ▼               ▼                   ▼               ▼
     Server Cert      Client Cert        Server Cert      Client Cert
     (ephemeral)      (persistent)       (ephemeral)      (persistent)
          │               │                   │               │
          │               │                   │               │
          ▼               │                   ▼               │
   Management Server      │              Log Server           │
          │               │                   │               │
          │               │                   │               │
          └─────── mTLS ──┘                   └────── mTLS ───┘
                  │                                   │
                  │                                   │
             karmor management                   karmor logs
```